### PR TITLE
Improved repeat functionality

### DIFF
--- a/docs/operators.md
+++ b/docs/operators.md
@@ -4,9 +4,11 @@
   * `dw` - with a motion
   * `3d2w` - with repeating operator and motion
   * `dd` - linewise
+  * `d2d` - repeated linewise
 * [Yank](http://vimhelp.appspot.com/change.txt.html#yank)
   * `yw` - with a motion
   * `yy` - linewise
+  * `y2y` - repeated linewise
   * `"ayy` - supports registers (only named a-h, pending more
     advanced atom keymap support)
 * [Put](http://vimhelp.appspot.com/change.txt.html#p)

--- a/lib/commands.coffee
+++ b/lib/commands.coffee
@@ -1,16 +1,19 @@
+_ = require 'underscore'
+
 class Command
   constructor: (@editor) ->
   isComplete: -> true
 
 class DeleteRight extends Command
-  execute: ->
-    rowLength = @editor.getCursor().getCurrentBufferLine().length
-    return if rowLength == 0
+  execute: (count=1) ->
+    _.times count, =>
+      rowLength = @editor.getCursor().getCurrentBufferLine().length
+      return if rowLength == 0
 
-    @editor.delete()
-    rowLength -= 1
+      @editor.delete()
+      rowLength -= 1
 
-    {column, row} = @editor.getCursorScreenPosition()
-    @editor.moveCursorLeft() if column == rowLength
+      {column, row} = @editor.getCursorScreenPosition()
+      @editor.moveCursorLeft() if column == rowLength
 
 module.exports = { DeleteRight }

--- a/lib/motions.coffee
+++ b/lib/motions.coffee
@@ -1,63 +1,77 @@
+_ = require 'underscore'
+
 Point = require 'point'
+Range = require 'range'
 
 class Motion
   constructor: (@editor) ->
   isComplete: -> true
 
 class MoveLeft extends Motion
-  execute: ->
-    {row, column} = @editor.getCursorScreenPosition()
-    @editor.moveCursorLeft() if column > 0
+  execute: (count=1) ->
+    _.map [1..count], =>
+      {row, column} = @editor.getCursorScreenPosition()
+      @editor.moveCursorLeft() if column > 0
 
-  select: ->
-    {row, column} = @editor.getCursorScreenPosition()
+  select: (count=1) ->
+    _.map [1..count], =>
+      {row, column} = @editor.getCursorScreenPosition()
 
-    if column > 0
-      @editor.selectLeft()
-      true
-    else
-      false
+      if column > 0
+        @editor.selectLeft()
+        true
+      else
+        false
 
 class MoveRight extends Motion
-  execute: ->
-    {row, column} = @editor.getCursorScreenPosition()
-    lastCharIndex = @editor.getBuffer().lineForRow(row).length - 1
-    unless column >= lastCharIndex
-      @editor.moveCursorRight()
+  execute: (count=1) ->
+    _.map [1..count], =>
+      {row, column} = @editor.getCursorScreenPosition()
+      lastCharIndex = @editor.getBuffer().lineForRow(row).length - 1
+      unless column >= lastCharIndex
+        @editor.moveCursorRight()
 
 class MoveUp extends Motion
-  execute: ->
-    {row, column} = @editor.getCursorScreenPosition()
-    @editor.moveCursorUp() if row > 0
+  execute: (count=1) ->
+    _.map [1..count], =>
+      {row, column} = @editor.getCursorScreenPosition()
+      @editor.moveCursorUp() if row > 0
 
 class MoveDown extends Motion
-  execute: ->
-    {row, column} = @editor.getCursorScreenPosition()
-    @editor.moveCursorDown() if row < (@editor.getBuffer().getLineCount() - 1)
+  execute: (count=1) ->
+    _.map [1..count], =>
+      {row, column} = @editor.getCursorScreenPosition()
+      @editor.moveCursorDown() if row < (@editor.getBuffer().getLineCount() - 1)
 
 class MoveToPreviousWord extends Motion
-  execute: ->
-    @editor.moveCursorToBeginningOfWord()
+  execute: (count=1) ->
+    _.map [1..count], =>
+      @editor.moveCursorToBeginningOfWord()
 
-  select: ->
-    @editor.selectToBeginningOfWord()
-    true
+  select: (count=1) ->
+    _.map [1..count], =>
+      @editor.selectToBeginningOfWord()
+      true
 
 class MoveToNextWord extends Motion
-  execute: ->
-    @editor.moveCursorToBeginningOfNextWord()
+  execute: (count=1) ->
+    _.map [1..count], =>
+      @editor.moveCursorToBeginningOfNextWord()
 
-  select: ->
-    @editor.selectToBeginningOfNextWord()
-    true
+  select: (count=1) ->
+    _.map [1..count], =>
+      @editor.selectToBeginningOfNextWord()
+      true
 
 class MoveToNextParagraph extends Motion
-  execute: ->
-    @editor.setCursorScreenPosition(@nextPosition())
+  execute: (count=1) ->
+    _.map [1..count], =>
+      @editor.setCursorScreenPosition(@nextPosition())
 
-  select: ->
-    @editor.selectToScreenPosition(@nextPosition())
-    true
+  select: (count=1) ->
+    _.map [1..count], =>
+      @editor.selectToScreenPosition(@nextPosition())
+      true
 
   # Finds the beginning of the next paragraph
   #
@@ -76,20 +90,57 @@ class MoveToNextParagraph extends Motion
 
     @editor.screenPositionForBufferPosition(position)
 
-class MoveToFirstCharacterOfLine extends Motion
-  execute: ->
-    @editor.moveCursorToFirstCharacterOfLine()
+class MoveToLine extends Motion
+  isLinewise: -> true
 
-  select: ->
-    @editor.selectToFirstCharacterOfLine()
-    true
+  execute: (count=1) ->
+    # noop
+
+  select: (count=1) ->
+    {row, column} = @editor.getCursorBufferPosition()
+    @editor.setSelectedBufferRange(@selectRows(row, row+(count-1)))
+
+    _.map [1..count], (i) =>
+      true
+
+   # TODO: This is extracted from TextBuffer#deleteRows. Unfortunately
+   # there isn't a way to call this functionality without actually
+   # deleting at the same time. This should be extracted out within atom
+   # and the removed here.
+   selectRows: (start, end) =>
+     startPoint = null
+     endPoint = null
+     buffer = @editor.getBuffer()
+     if end == buffer.getLastRow()
+       if start > 0
+         startPoint = [start - 1, buffer.lineLengthForRow(start - 1)]
+       else
+         startPoint = [start, 0]
+       endPoint = [end, buffer.lineLengthForRow(end)]
+     else
+       startPoint = [start, 0]
+       endPoint = [end + 1, 0]
+
+      new Range(startPoint, endPoint)
+
+class MoveToFirstCharacterOfLine extends Motion
+  execute: (count=1) ->
+    _.map [1..count], =>
+      @editor.moveCursorToFirstCharacterOfLine()
+
+  select: (count=1) ->
+    _.map [1..count], =>
+      @editor.selectToFirstCharacterOfLine()
+      true
 
 class MoveToLastCharacterOfLine extends Motion
-  execute: ->
-    @editor.moveCursorToEndOfLine()
+  execute: (count=1) ->
+    _.map [1..count], =>
+      @editor.moveCursorToEndOfLine()
 
-  select: ->
-    @editor.selectToEndOfLine()
-    true
+  select: (count=1) ->
+    _.map [1..count], =>
+      @editor.selectToEndOfLine()
+      true
 
-module.exports = { Motion, MoveLeft, MoveRight, MoveUp, MoveDown, MoveToNextWord, MoveToPreviousWord, MoveToNextParagraph, MoveToFirstCharacterOfLine, MoveToLastCharacterOfLine }
+module.exports = { Motion, MoveLeft, MoveRight, MoveUp, MoveDown, MoveToNextWord, MoveToPreviousWord, MoveToNextParagraph, MoveToFirstCharacterOfLine, MoveToLastCharacterOfLine, MoveToLine }

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -31,9 +31,9 @@ class VimState
       'activate-command-mode': => @activateCommandMode()
       'reset-command-mode': => @resetCommandMode()
       'insert': => @activateInsertMode()
-      'delete': => @delete()
+      'delete': => @linewiseAliasedOperator(operators.Delete)
       'delete-right': => new commands.DeleteRight(@editor)
-      'yank': => @yank()
+      'yank': => @linewiseAliasedOperator(operators.Yank)
       'put-after': => new operators.Put(@editor, @)
       'move-left': => new motions.MoveLeft(@editor)
       'move-up': => new motions.MoveUp(@editor)
@@ -86,19 +86,13 @@ class VimState
     else
       @pushOperator(new operators.NumericPrefix(num))
 
-  delete: () ->
-    if deleteOperation = @isOperatorPending(operators.Delete)
-      deleteOperation.complete = true
-      @processOpStack()
+  linewiseAliasedOperator: (operator) ->
+    if @isOperatorPending(operator)
+      op = new motions.MoveToLine(@editor)
     else
-      @pushOperator(new operators.Delete(@editor))
+      op = new operator(@editor, @)
 
-  yank: () ->
-    if yankOperation = @isOperatorPending(operators.Yank)
-      yankOperation.complete = true
-      @processOpStack()
-    else
-      @pushOperator(new operators.Yank(@editor, @))
+    @pushOperator(op)
 
   isOperatorPending: (type) ->
     for op in @opStack

--- a/spec/vim-mode-spec.coffee
+++ b/spec/vim-mode-spec.coffee
@@ -129,8 +129,7 @@ describe "VimState", ->
           expect(editor.getText()).toBe "12345\nabcde"
           expect(editor.getCursorScreenPosition()).toEqual([1,0])
 
-        # FIXME: This functionality wasn't implemented previously.
-        xdescribe "when the second d is prefixed by a count", ->
+        describe "when the second d is prefixed by a count", ->
           it "deletes n lines, starting from the current", ->
             editor.setText("12345\nabcde\nABCDE\nQWERT")
             editor.setCursorScreenPosition([1,1])
@@ -203,7 +202,7 @@ describe "VimState", ->
 
     describe "the y keybinding", ->
       beforeEach ->
-        editor.getBuffer().setText "012 345\n"
+        editor.getBuffer().setText "012 345\nabc\n"
         editor.setCursorScreenPosition [0, 0]
 
       it "saves the line to the default register", ->
@@ -211,6 +210,14 @@ describe "VimState", ->
         keydown('y', element: editor[0])
 
         expect(vimState.getRegister('"')).toBe "012 345\n"
+
+      describe "when the second y is prefixed by a count", ->
+        it "deletes n lines, starting from the current", ->
+          keydown('y', element: editor[0])
+          keydown('2', element: editor[0])
+          keydown('y', element: editor[0])
+
+          expect(vimState.getRegister('"')).toBe "012 345\nabc\n"
 
       it "saves the line to the a register", ->
         keydown('"', element: editor[0])


### PR DESCRIPTION
This ended up being a pretty large change as implementing these two sequences uncovered a weakness in the NumberPrefix operator. Not all operations can be simply repeated. In yank's case it would just copy a single line instead of two. This wasn't obvious previously as calling delete line twice actually does what you would expect.

Therefore I changed the select method, to always take a count and return an array of whether the selection was successful. While this requires more typing I believe it better communicates to future committers that they need to consider how their new operation or motion works in a repetitive manner.
