### PR TITLE
Implement 'O' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ them useful as no one person uses all of vim's functionality.
 
 ### Future Work (in rough order)
 
-* Implement `O` operator.
 * Implement `J` operator.
 * Implement `a` command.
 * Implement `>>` and `<<` operators.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -4,3 +4,4 @@
 * Motions have repeat support, `d3w` will delete three words.
 * Registers exist but are limited to just named registers (a-h) and the
   default buffer doesn't yet save on delete operations.
+* Insert mode can be entered using 'i' or 'O'.

--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -28,6 +28,7 @@
   'i': 'vim-mode:insert'
   'd': 'vim-mode:delete'
   'D': 'vim-mode:delete-to-last-character-of-line'
+  'O': 'vim-mode:insert-above-with-newline'
   'x': 'vim-mode:delete-right'
   'y': 'vim-mode:yank'
   'p': 'vim-mode:put-after'

--- a/lib/commands.coffee
+++ b/lib/commands.coffee
@@ -1,7 +1,18 @@
 _ = require 'underscore'
 
 class Command
-  constructor: (@editor) ->
+  constructor: (@editor, @vimState) ->
   isComplete: -> true
 
-module.exports = { }
+class Insert extends Command
+  execute: (count=1) ->
+    @vimState.activateInsertMode()
+
+class InsertAboveWithNewline extends Command
+  execute: (count=1) ->
+    @vimState.activateInsertMode()
+    @editor.insertNewlineAbove()
+    @editor.moveCursorUp()
+    @editor.moveCursorToBeginningOfLine()
+
+module.exports = { Insert, InsertAboveWithNewline }

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -48,7 +48,8 @@ class VimState
     @handleCommands
       'activate-command-mode': => @activateCommandMode()
       'reset-command-mode': => @resetCommandMode()
-      'insert': => @activateInsertMode()
+      'insert': => new commands.Insert(@editor, @)
+      'insert-above-with-newline': => new commands.InsertAboveWithNewline(@editor, @)
       'delete': => @linewiseAliasedOperator(operators.Delete)
       'delete-right': => [new operators.Delete(@editor), new motions.MoveRight(@editor)]
       'delete-to-last-character-of-line': => [new operators.Delete(@editor), new motions.MoveToLastCharacterOfLine(@editor)]
@@ -148,6 +149,16 @@ class VimState
   setRegister: (name, value) ->
     @registers[name] = value
 
+  # Private: Used to enable insert mode.
+  #
+  # Returns nothing.
+  activateInsertMode: ->
+    @mode = 'insert'
+    @editor.removeClass('command-mode')
+    @editor.addClass('insert-mode')
+
+    @editor.off 'cursor:position-changed', @moveCursorBeforeNewline
+
   ##############################################################################
   # Commands
   ##############################################################################
@@ -161,16 +172,6 @@ class VimState
     @editor.addClass('command-mode')
 
     @editor.on 'cursor:position-changed', @moveCursorBeforeNewline
-
-  # Private: Used to enable insert mode.
-  #
-  # Returns nothing.
-  activateInsertMode: ->
-    @mode = 'insert'
-    @editor.removeClass('command-mode')
-    @editor.addClass('insert-mode')
-
-    @editor.off 'cursor:position-changed', @moveCursorBeforeNewline
 
   # Private: Resets the command mode back to it's initial state.
   #

--- a/spec/vim-mode-spec.coffee
+++ b/spec/vim-mode-spec.coffee
@@ -263,6 +263,18 @@ describe "VimState", ->
 
         expect(editor.getText()).toBe "0\n"
 
+    describe "the O keybinding", ->
+      beforeEach ->
+        editor.getBuffer().setText "012\n"
+        editor.setCursorScreenPosition [0, 1]
+
+      it "deletes the contents until the end of the line", ->
+        keydown('O', shift: true, element: editor[0])
+
+        expect(editor.getText()).toBe "\n012\n"
+        expect(editor.getCursorScreenPosition()).toEqual [0,0]
+        expect(editor).toHaveClass 'insert-mode'
+
     describe "basic motion bindings", ->
       beforeEach ->
         editor.setText("12345\nabcde\nABCDE")


### PR DESCRIPTION
This allows you to jump into insert mode quickly with a newline above your current cursor.

This also refactors out the insert mode commands into commands.coffee as opposed to on VimState.
