### PR TITLE
move over entirely to using `keydown` instead of triggering `keydownEvent`

### DIFF
--- a/spec/vim-mode-spec.coffee
+++ b/spec/vim-mode-spec.coffee
@@ -33,7 +33,7 @@ describe "VimState", ->
       e.initTextEvent eventArgs...
       target.dispatchEvent e
 
-    key = "U+#{key.charCodeAt(0).toString(16)}"
+    key = "U+#{key.charCodeAt(0).toString(16)}" unless key == "escape"
     element ||= document.activeElement
     eventArgs = [true, true, null, key, 0, ctrl, alt, shift, meta] # bubbles, cancelable, view, key, location
 


### PR DESCRIPTION
As was mentioned in https://github.com/atom/vim-mode/pull/14#discussion_r5719629, here's a PR for getting rid of all the old `editor.trigger keydownEvent`.
