### PR TITLE
linewise operations paying attention to "screen lines"

### DIFF
--- a/spec/vim-mode-spec.coffee
+++ b/spec/vim-mode-spec.coffee
@@ -368,7 +368,7 @@ describe "VimState", ->
         keydown('y', element: editor[0])
 
         expect(vimState.getRegister('"').text).toBe text
-        expect(editor.getCursorScreenPosition()).toEqual([0,4])
+        expect(editor.getCursorScreenPosition()).toEqual([0,0])
         expect(editor.activeEditSession.isFoldedAtBufferRow()).toBe true
 
       describe "when the second y is prefixed by a count", ->


### PR DESCRIPTION
Trying to treat folds as single lines for the linewise operations.

There was some discussion of this in chat and also in person. It may end up with a third set of coördinates, but for now I'm just trying to go for screen as opposed to buffer. And I think I may be doing this entirely incorrectly.

Please feel free to point me in the right direction, @atom/core, @mcolyer.
