### PR TITLE
Add undo/redo for repeated operators

### DIFF
--- a/lib/operators.coffee
+++ b/lib/operators.coffee
@@ -106,15 +106,17 @@ class Delete
   # Returns nothing.
   execute: (count=1) ->
     cursor = @editor.getCursor()
+    buffer = @editor.getBuffer()
 
-    _.times count, =>
-      if _.last(@motion.select(1, @selectOptions))
-        @editor.getSelection().delete()
+    buffer.transact =>
+      _.times count, =>
+        if _.last(@motion.select(1, @selectOptions))
+          @editor.getSelection().delete()
 
-      @editor.moveCursorLeft() if cursor.isAtEndOfLine() and !@motion.isLinewise?()
+        @editor.moveCursorLeft() if cursor.isAtEndOfLine() and !@motion.isLinewise?()
 
-    if @motion.isLinewise?()
-      @editor.setCursorScreenPosition([cursor.getScreenRow(), 0])
+      if @motion.isLinewise?()
+        @editor.setCursorScreenPosition([cursor.getScreenRow(), 0])
 
   # Public: Marks this as complete and saves the motion.
   #
@@ -310,19 +312,21 @@ class Put
   execute: (count=1) ->
     {text, type} = @vimState.getRegister(@register) || {}
     return unless text
+    buffer = @editor.getBuffer()
 
-    _.times count, =>
-      if type == 'linewise' and @location == 'after'
-        @editor.moveCursorDown()
-      else if @location == 'after'
-        @editor.moveCursorRight()
+    buffer.transact =>
+      _.times count, =>
+        if type == 'linewise' and @location == 'after'
+          @editor.moveCursorDown()
+        else if @location == 'after'
+          @editor.moveCursorRight()
 
-      @editor.moveCursorToBeginningOfLine() if type == 'linewise'
-      @editor.insertText(text)
+        @editor.moveCursorToBeginningOfLine() if type == 'linewise'
+        @editor.insertText(text)
 
-      if type == 'linewise'
-        @editor.moveCursorUp()
-        @editor.moveCursorToFirstCharacterOfLine()
+        if type == 'linewise'
+          @editor.moveCursorUp()
+          @editor.moveCursorToFirstCharacterOfLine()
 
   # Public: Not implemented.
   #
@@ -344,8 +348,11 @@ class Join
   #
   # Returns nothing.
   execute: (count=1) ->
-    _.times count, =>
-      @editor.joinLine()
+    buffer = @editor.getBuffer()
+
+    buffer.transact =>
+      _.times count, =>
+        @editor.joinLine()
 
   # Public: Not implemented.
   #

--- a/spec/vim-mode-spec.coffee
+++ b/spec/vim-mode-spec.coffee
@@ -899,6 +899,45 @@ describe "VimState", ->
 
         expect(editor.getText()).toBe 'three'
 
+  describe "undo", ->
+    describe "delete operator", ->
+      it "handles repeats", ->
+        editor.setText("12345\nabcde\nABCDE\nQWERT")
+        editor.setCursorScreenPosition([1,1])
+
+        keydown('d', element: editor[0])
+        keydown('2', element: editor[0])
+        keydown('d', element: editor[0])
+
+        keydown('u', element: editor[0])
+
+        expect(editor.getText()).toBe "12345\nabcde\nABCDE\nQWERT"
+
+    describe "put operator", ->
+      it "handles repeats", ->
+        editor.setText("12345\nabcde\nABCDE\nQWERT")
+        editor.setCursorScreenPosition([1,1])
+        vimState.setRegister('"', text: "123")
+
+        keydown('2', element: editor[0])
+        keydown('p', element: editor[0])
+
+        keydown('u', element: editor[0])
+
+        expect(editor.getText()).toBe "12345\nabcde\nABCDE\nQWERT"
+
+    describe "join operator", ->
+      it "handles repeats", ->
+        editor.setText("12345\nabcde\nABCDE\nQWERT")
+        editor.setCursorScreenPosition([1,1])
+
+        keydown('2', element: editor[0])
+        keydown('J', shift: true, element: editor[0])
+
+        keydown('u', element: editor[0])
+
+        expect(editor.getText()).toBe "12345\nabcde\nABCDE\nQWERT"
+
   describe "insert-mode", ->
     beforeEach ->
       keydown('i', element: editor[0])


### PR DESCRIPTION
This fixes the issue where if you undid `2dd` it would only undo the last deleted line, now it correctly would replace both deleted lines. It also handles Joins and Put operations as well.

I'd like this to supersede #18 and then address #11 in the future for yanking support.

@bhuga are you cool with this?
