### PR TITLE
More delete issues

### DIFF
--- a/spec/vim-mode-spec.coffee
+++ b/spec/vim-mode-spec.coffee
@@ -172,6 +172,45 @@ describe "VimState", ->
             expect(editor.getText()).toBe "12345\nQWERT"
             expect(editor.getCursorScreenPosition()).toEqual([1,0])
 
+          it "pastes n lines back when pressing p", ->
+            editor.setText("12345\nabcde\nABCDE\nQWERT")
+            editor.setCursorScreenPosition([1,1])
+
+            keydown('d', element: editor[0])
+            keydown('2', element: editor[0])
+            keydown('d', element: editor[0])
+
+            editor.setCursorScreenPosition([1,1])
+            keydown('p', element: editor[0])
+
+            expect(editor.getText()).toBe "12345\nQWERT\nabcde\nABCDE"
+            expect(editor.getCursorScreenPosition()).toEqual([1,0])
+
+        describe "when preceeded by numbers", ->
+          beforeEach ->
+            editor.setText("111\n222\n333\n444")
+            editor.setCursorScreenPosition([1,1])
+
+          it "deletes n lines, starting from the current", ->
+            keydown('2', element: editor[0])
+            keydown('d', element: editor[0])
+            keydown('d', element: editor[0])
+
+            expect(editor.getText()).toBe "111\n444"
+            expect(editor.getCursorScreenPosition()).toEqual([1,0])
+
+          it "pastes deleted lines", ->
+            keydown('2', element: editor[0])
+            keydown('d', element: editor[0])
+            keydown('d', element: editor[0])
+
+            editor.setCursorScreenPosition([1,1])
+            keydown('p', element: editor[0])
+
+            expect(editor.getText()).toBe "111\n444\n222\n333"
+            expect(editor.getCursorScreenPosition()).toEqual([2,0])
+
+
       describe "when followed by an h", ->
         it "deletes the previous letter on the current line", ->
           editor.setText("abcd\n01234")


### PR DESCRIPTION
Don't merge, this is just failing tests for the next stuff I want to work on:

`d2dp` pastes the lines a line up from where they should be. In vim, this operation will end up pasting the lines a line down from where they once were, and in atom currently they end up exactly where they came from.

`2ddp` just pastes one line, also wrong.
