### PR TITLE
Fix repeating operators

### DIFF
--- a/lib/operators.coffee
+++ b/lib/operators.coffee
@@ -174,19 +174,21 @@ class Put extends Operator
     {text, type} = @vimState.getRegister(@register) || {}
     return unless text
 
-    @undoTransaction =>
-      _.times count, =>
-        if type == 'linewise' and @location == 'after'
-          @editor.moveCursorDown()
-        else if @location == 'after'
-          @editor.moveCursorRight()
+    if @location == 'after'
+      if type == 'linewise'
+        @editor.moveCursorDown()
+      else
+        @editor.moveCursorRight()
 
-        @editor.moveCursorToBeginningOfLine() if type == 'linewise'
-        @editor.insertText(text)
+    if type == 'linewise'
+      @editor.moveCursorToBeginningOfLine()
 
-        if type == 'linewise'
-          @editor.moveCursorUp()
-          @editor.moveCursorToFirstCharacterOfLine()
+    textToInsert = _.times(count, -> text).join('')
+    @editor.insertText(textToInsert)
+
+    if type == 'linewise'
+      @editor.moveCursorUp()
+      @editor.moveCursorToFirstCharacterOfLine()
 
 #
 # It combines the current line with the following line.

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -277,17 +277,23 @@ describe "Operators", ->
         expect(editor.getText()).toBe "012\n 345\n"
         expect(editor.getCursorScreenPosition()).toEqual [1, 1]
 
-    describe "undo behavior", ->
+    describe "pasting twice", ->
       beforeEach ->
         editor.setText("12345\nabcde\nABCDE\nQWERT")
         editor.setCursorScreenPosition([1, 1])
         vimState.setRegister('"', text: '123')
         keydown('2')
         keydown('p')
-        keydown('u')
 
-      it "handles repeats", ->
-        expect(editor.getText()).toBe "12345\nabcde\nABCDE\nQWERT"
+      it "inserts the same line twice", ->
+        expect(editor.getText()).toBe "12345\nab123123cde\nABCDE\nQWERT"
+
+      describe "when undone", ->
+        beforeEach ->
+          keydown('u')
+
+        it "removes both lines", ->
+          expect(editor.getText()).toBe "12345\nabcde\nABCDE\nQWERT"
 
   describe "the P keybinding", ->
     describe "with character contents", ->


### PR DESCRIPTION
Now, all repeated operators (such as `2dd`) will correctly place their deleted content in the `"` register, where previously only `d2d` did the right thing.
