### PR TITLE
Fix regression in 'b' motion due to refactor

### DIFF
--- a/lib/motions.coffee
+++ b/lib/motions.coffee
@@ -56,7 +56,7 @@ class MoveDown extends Motion
 
 class MoveToPreviousWord extends Motion
   execute: (count=1) ->
-    _.time count, =>
+    _.times count, =>
       @editor.moveCursorToBeginningOfWord()
 
   select: (count=1) ->

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -197,7 +197,7 @@ describe "Motions", ->
     describe "as a motion", ->
       beforeEach -> editor.setCursorScreenPosition([4,1])
 
-      xit "moves the cursor to the beginning of the previous word", ->
+      it "moves the cursor to the beginning of the previous word", ->
         keydown('b')
         expect(editor.getCursorScreenPosition()).toEqual [3, 4]
 
@@ -224,11 +224,11 @@ describe "Motions", ->
         # we change this behavior.
         #
         # See atom/vim-mode#3
-        keydown('b')
-        expect(editor.getCursorScreenPosition()).toEqual [0, 0]
+        #keydown('b')
+        #expect(editor.getCursorScreenPosition()).toEqual [0, 0]
 
-        keydown('b')
-        expect(editor.getCursorScreenPosition()).toEqual [0, 0]
+        #keydown('b')
+        #expect(editor.getCursorScreenPosition()).toEqual [0, 0]
 
     describe "as a selection", ->
       describe "within a word", ->


### PR DESCRIPTION
I had a typo in my refactor branch that I missed because the `b` motion tests were entirely crossed out. This branch re-enables the portion of the specs which do pass to prevent this from happening in the future.
