### PR TITLE
Update vim-mode to work with atom >20.0

### DIFF
--- a/lib/motions.coffee
+++ b/lib/motions.coffee
@@ -1,7 +1,6 @@
 _ = require 'underscore'
 
-Point = require 'point'
-Range = require 'range'
+{Point, Range} = require 'telepath'
 
 class Motion
   constructor: (@editor) ->

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/atom/vim-mode/issues"
   },
   "engines": {
-    "atom": "*"
+    "atom": ">20.0"
   },
   "publishConfig": {
     "registry": "https://atom.iriscouch.com/registry/_design/app/_rewrite"


### PR DESCRIPTION
:warning: Not ready to be merged :warning: 

If you are running Atom from HEAD you'll need these changes in order to use vim-mode. However I won't be merging this pull until Atom 21.0 is released. 

Don't branch off of this branch as it will be rebased to track head of vim-mode until the release is cut, you've been warned.
