### PR TITLE
Fix putting at the end of lines

### DIFF
--- a/lib/operators.coffee
+++ b/lib/operators.coffee
@@ -186,7 +186,8 @@ class Put extends Operator
         else
           @editor.moveCursorDown()
       else
-        @editor.moveCursorRight()
+        unless @onLastColumn()
+          @editor.moveCursorRight()
 
     if type == 'linewise' and !originalPosition?
       @editor.moveCursorToBeginningOfLine()
@@ -208,6 +209,8 @@ class Put extends Operator
     {row, column} = @editor.getCursorBufferPosition()
     row == @editor.getBuffer().getLastRow()
 
+  onLastColumn: ->
+    @editor.getCursor().isAtEndOfLine()
 #
 # It combines the current line with the following line.
 #

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -266,6 +266,20 @@ describe "Operators", ->
           expect(editor.getText()).toBe "0a12\n"
           expect(editor.getCursorScreenPosition()).toEqual [0, 2]
 
+      describe "at the end of a line", ->
+        it "inserts before the current line's newline", ->
+          editor.setText("abcde\none two three")
+          editor.setCursorScreenPosition([1, 4])
+
+          keydown 'd'
+          keydown '$'
+          keydown 'k'
+          keydown '$'
+          keydown 'p'
+
+          expect(editor.getText()).toBe "abcdetwo three\none "
+
+
     describe "with linewise contents", ->
       beforeEach ->
         editor.getBuffer().setText("012")


### PR DESCRIPTION
Putting non-linewise characters currently moves the buffer a position to the right to get the position the same as vim. This breaks at the end of line, where we move to the next one. Adds a special case for putting character-wise paste data at the end of a line.
