### PR TITLE
Use sync open in specs

### DIFF
--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -5,11 +5,12 @@ VimState = require '../lib/vim-state'
 originalKeymap = null
 
 cacheEditor = (existingEditor) ->
+  session = window.project.openSync()
   if existingEditor?
-    existingEditor.edit(window.project.open())
+    existingEditor.edit(session)
     existingEditor.vimState.registerChangeHandler(existingEditor.getBuffer())
   else
-    editor = new Editor(project.open())
+    editor = new Editor(session)
     editor.simulateDomAttachment()
     editor.enableKeymap()
 

--- a/spec/vim-mode-spec.coffee
+++ b/spec/vim-mode-spec.coffee
@@ -5,7 +5,7 @@ describe "VimMode", ->
 
   beforeEach ->
     window.rootView = new RootView
-    rootView.open()
+    rootView.openSync()
     rootView.simulateDomAttachment()
     atom.activatePackage('vim-mode', immediate: true)
 


### PR DESCRIPTION
Somewhere along the line, this seems to have become required by atom mainline.
