### PR TITLE
Compatibility with Atom v40

### DIFF
--- a/lib/vim-mode.coffee
+++ b/lib/vim-mode.coffee
@@ -3,8 +3,8 @@ VimState = require './vim-state'
 module.exports =
 
   activate: (state) ->
-    atom.rootView.eachEditor (editor) =>
-      return unless editor.attached
+    atom.workspaceView.eachEditorView (editorView) =>
+      return unless editorView.attached
 
-      editor.addClass('vim-mode')
-      editor.vimState = new VimState(editor)
+      editorView.addClass('vim-mode')
+      editorView.vimState = new VimState(editorView)

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -335,8 +335,8 @@ describe "Operators", ->
 
   describe "the O keybinding", ->
     beforeEach ->
-      spyOn(editor.activeEditSession, 'shouldAutoIndent').andReturn(true)
-      spyOn(editor.activeEditSession, 'autoIndentBufferRow').andCallFake (line) ->
+      spyOn(editor.editor, 'shouldAutoIndent').andReturn(true)
+      spyOn(editor.editor, 'autoIndentBufferRow').andCallFake (line) ->
         editor.indent()
 
       editor.getBuffer().setText("  abc\n  012\n")
@@ -350,8 +350,8 @@ describe "Operators", ->
 
   describe "the o keybinding", ->
     beforeEach ->
-      spyOn(editor.activeEditSession, 'shouldAutoIndent').andReturn(true)
-      spyOn(editor.activeEditSession, 'autoIndentBufferRow').andCallFake (line) ->
+      spyOn(editor.editor, 'shouldAutoIndent').andReturn(true)
+      spyOn(editor.editor, 'autoIndentBufferRow').andCallFake (line) ->
         editor.indent()
 
       editor.getBuffer().setText("abc\n  012\n")

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -1,4 +1,4 @@
-{Editor} = require 'atom'
+{EditorView} = require 'atom'
 
 VimState = require '../lib/vim-state'
 
@@ -10,7 +10,7 @@ cacheEditor = (existingEditor) ->
     existingEditor.edit(session)
     existingEditor.vimState.registerChangeHandler(existingEditor.getBuffer())
   else
-    editor = new Editor(session)
+    editor = new EditorView(session)
     editor.simulateDomAttachment()
     editor.enableKeymap()
 

--- a/spec/vim-mode-spec.coffee
+++ b/spec/vim-mode-spec.coffee
@@ -1,15 +1,15 @@
-{RootView} = require 'atom'
+{WorkspaceView} = require 'atom'
 
 describe "VimMode", ->
   [editor] = []
 
   beforeEach ->
-    atom.rootView = new RootView
-    atom.rootView.openSync()
-    atom.rootView.simulateDomAttachment()
+    atom.workspaceView = new WorkspaceView
+    atom.workspaceView.openSync()
+    atom.workspaceView.simulateDomAttachment()
     atom.packages.activatePackage('vim-mode', immediate: true)
 
-    editor = atom.rootView.getActiveView()
+    editor = atom.workspaceView.getActiveView()
     editor.enableKeymap()
 
   describe "initialize", ->


### PR DESCRIPTION
If you're running master of Atom and you'd like to use vim-mode, you'll need to run on this branch until v40 is released.
## Changes
- Switch to WorkspaceView and EditorView
