### PR TITLE
Change visual-mode to display cursor as block

### DIFF
--- a/stylesheets/vim-mode.less
+++ b/stylesheets/vim-mode.less
@@ -1,8 +1,14 @@
-.vim-mode.command-mode {
-  .cursor, .cursor.blink-off {
+.block-cursor() {
     border: 0;
     background-color: white;
     visibility: visible;
     opacity: 0.5;
+}
+
+.editor.vim-mode {
+  &.visual-mode, &.command-mode {
+    .cursor, .cursor.blink-off {
+      .block-cursor();
+    }
   }
 }


### PR DESCRIPTION
When entering visual mode, cursor was being displayed as a text cursor
