### PR TITLE
Move left after exiting insert mode

### DIFF
--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -222,6 +222,10 @@ class VimState
   activateCommandMode: ->
     @mode = 'command'
     @submode = null
+
+    if @editorView.is(".insert-mode")
+      @editor.getCursor().moveLeft()
+
     @editorView.removeClass('insert-mode visual-mode')
     @editorView.addClass('command-mode')
 

--- a/spec/vim-state-spec.coffee
+++ b/spec/vim-state-spec.coffee
@@ -104,6 +104,13 @@ describe "VimState", ->
     describe "with content", ->
       beforeEach -> editor.setText("012345\n\nabcdef")
 
+      describe "when cursor is in the middle of the line", ->
+        beforeEach -> editor.setCursorScreenPosition([0,3])
+
+        it "moves the cursor to the left when exiting insert mode", ->
+          keydown('escape')
+          expect(editor.getCursorScreenPosition()).toEqual [0,2]
+
       describe "on a line with content", ->
         beforeEach -> editor.setCursorScreenPosition([0, 6])
 


### PR DESCRIPTION
This matches actual Vim behavior. If I go into insert mode and ESC over and over again, the cursor should keep moving left.
