### PR TITLE
Adjust 'backspace' in command mode

### DIFF
--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -86,3 +86,4 @@
   'n': 'command-panel:repeat-relative-address'
   'N': 'command-panel:repeat-relative-address-in-reverse'
   'ctrl-c': 'vim-mode:reset-command-mode'
+  'backspace': 'core:move-left'


### PR DESCRIPTION
In vim while in command mode 'backspace' will move the cursor left not delete characters.

Fixes issue#56
