### PR TITLE
"enter" key should move down one line in normal mode.

### DIFF
--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -76,6 +76,7 @@
   '.': 'vim-mode:repeat'
   # '0': 'vim-mode:move-to-beginning-of-line'
   'g g': 'vim-mode:move-to-start-of-file'
+  'enter': 'vim-mode:move-down'
   'G': 'vim-mode:move-to-line'
   'escape': 'vim-mode:reset-command-mode'
   'u': 'core:undo'


### PR DESCRIPTION
I'm not totally sure where this should go order-wise in the keymappings. I didn't really want to break up the `hjkl` stuff and it looked weird breaking up the vertical alignment of the single key maps.
