### PR TITLE
visual mode default keybinding: delete with x

### DIFF
--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -13,6 +13,7 @@
   'w': 'vim-mode:move-to-next-word'
   'e': 'vim-mode:move-to-end-of-word'
   'b': 'vim-mode:move-to-previous-word'
+  'x': 'vim-mode:delete'
   'd': 'vim-mode:delete'
   'c': 'vim-mode:change'
   'y': 'vim-mode:yank'


### PR DESCRIPTION
In visual mode x and d work similarly, but the binding for x was missing
from the defaults, so I added it.
