### PR TITLE
Map ':' to command-palette

### DIFF
--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -76,6 +76,7 @@
   '^': 'vim-mode:move-to-first-character-of-line'
   '$': 'vim-mode:move-to-last-character-of-line'
   '.': 'vim-mode:repeat'
+  ':': 'command-palette:toggle'
   # '0': 'vim-mode:move-to-beginning-of-line'
   'g g': 'vim-mode:move-to-start-of-file'
   'enter': 'vim-mode:move-down'


### PR DESCRIPTION
As a vim user I have the habit of always saving files with `:w`. Currently doing this on vim-mode would edit the buffer.

So mapping the `:` to the `command-palette` avoids this, and mimics the behaviour found in Sublime's vintage package. Although I think that vim-mode should add a different command prompt for this, instead of using the `command-palette`. But that might require Atom core changes and take some time.
