### PR TITLE
Fix a test failure on 0.62

### DIFF
--- a/lib/operators.coffee
+++ b/lib/operators.coffee
@@ -231,7 +231,7 @@ class Join extends Operator
   execute: (count=1) ->
     @undoTransaction =>
       _.times count, =>
-        @editor.joinLine()
+        @editor.joinLines()
 
 #
 # Repeat the last operation


### PR DESCRIPTION
Looks like `@editor.joinLine` became `@editor.joinLines`.
