### PR TITLE
Bump Atom dependency to 0.62

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "repository": "https://github.com/atom/vim-mode",
   "engines": {
-    "atom": ">0.50.0"
+    "atom": ">0.61.0"
   },
   "dependencies": {
     "underscore-plus": "1.x"


### PR DESCRIPTION
Atom made some API changes, therefore we need to bump our minimum dependency so that we can support the current latest version of Atom.

Note: If you are using Atom 0.60 or 0.61, v0.7.2 is the last compatible release.
