### PR TITLE
Add $ and ^ to visual mode

### DIFF
--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -22,6 +22,8 @@
   'y': 'vim-mode:yank'
   '>': 'vim-mode:indent'
   '<': 'vim-mode:outdent'
+  '$': 'vim-mode:move-to-last-character-of-line'
+  '^': 'vim-mode:move-to-first-character-of-line'
 
 '.vim-mode.command-mode:not(.mini)':
   'i': 'vim-mode:activate-insert-mode'


### PR DESCRIPTION
In Vim the $ and ^ move the cursor even in visual mode.  If there is something that I've missed just let me know.  Tips and advice are always welcome.
