### PR TITLE
Fix join lines

### DIFF
--- a/lib/operators.coffee
+++ b/lib/operators.coffee
@@ -231,7 +231,7 @@ class Join extends Operator
   execute: (count=1) ->
     @undoTransaction =>
       _.times count, =>
-        @editor.joinLines()
+        @editor.joinLine()
 
 #
 # Repeat the last operation


### PR DESCRIPTION
The tests for `J` were failing for me. This fixes them. I'm running Atom 0.60.0.
