### PR TITLE
Show cursor only in focused editor

### DIFF
--- a/stylesheets/vim-mode.less
+++ b/stylesheets/vim-mode.less
@@ -1,10 +1,20 @@
 @import "syntax-variables";
 
-.editor.is-focused.vim-mode.command-mode:not(.mini) {
+.block-cursor(@visibility: visible) {
+  border: 0;
+  background-color: @syntax-cursor-color;
+  visibility: @visibility;
+  opacity: 0.5;
+}
+
+.vim-mode.command-mode:not(.mini) {
   .cursor, .cursor.blink-off {
-    border: 0;
-    background-color: @syntax-cursor-color;
-    visibility: visible;
-    opacity: 0.5;
+    .block-cursor(hidden);
+  }
+
+  &.editor.is-focused {
+    .cursor, .cursor.blink-off {
+      .block-cursor;
+    }
   }
 }


### PR DESCRIPTION
It's confusing that the cursor is visible even when the editor window is not focused.So I fixed it :yellow_heart: 

But there's one problem left: You'll see the flash cursor when you click a different position from the origin position in the unfocused window. I think it's because the cursor becomes visible before its position changes.But I don't know how to fix it.Is it a bug of the core? :(
