### PR TITLE
Use buffer position instead of screen position

### DIFF
--- a/lib/motions.coffee
+++ b/lib/motions.coffee
@@ -38,7 +38,7 @@ class SelectRight extends Motion
 class MoveLeft extends Motion
   execute: (count=1) ->
     _.times count, =>
-      {row, column} = @editor.getCursorScreenPosition()
+      {row, column} = @editor.getCursorBufferPosition()
       @editor.moveCursorLeft() if column > 0
 
   select: (count=1) ->
@@ -54,7 +54,7 @@ class MoveLeft extends Motion
 class MoveRight extends Motion
   execute: (count=1) ->
     _.times count, =>
-      {row, column} = @editor.getCursorScreenPosition()
+      {row, column} = @editor.getCursorBufferPosition()
       lastCharIndex = @editor.getBuffer().lineForRow(row).length - 1
       unless column >= lastCharIndex
         @editor.moveCursorRight()
@@ -73,7 +73,7 @@ class MoveRight extends Motion
 class MoveUp extends Motion
   execute: (count=1) ->
     _.times count, =>
-      {row, column} = @editor.getCursorScreenPosition()
+      {row, column} = @editor.getCursorBufferPosition()
       @editor.moveCursorUp() if row > 0
 
   select: (count=1) ->
@@ -84,7 +84,7 @@ class MoveUp extends Motion
 class MoveDown extends Motion
   execute: (count=1) ->
     _.times count, =>
-      {row, column} = @editor.getCursorScreenPosition()
+      {row, column} = @editor.getCursorBufferPosition()
       @editor.moveCursorDown() if row < (@editor.getBuffer().getLineCount() - 1)
 
   select: (count=1) ->

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -27,10 +27,10 @@ describe "Motions", ->
       describe "as a motion", ->
         it "moves the cursor left, but not to the previous line", ->
           keydown('h')
-          expect(editor.getCursorScreenPosition()).toEqual [1, 0]
+          expect(editor.getCursorBufferPosition()).toEqual [1, 0]
 
           keydown('h')
-          expect(editor.getCursorScreenPosition()).toEqual [1, 0]
+          expect(editor.getCursorBufferPosition()).toEqual [1, 0]
 
       describe "as a selection", ->
         it "selects the character to the left", ->
@@ -43,28 +43,28 @@ describe "Motions", ->
     describe "the j keybinding", ->
       it "moves the cursor down, but not to the end of the last line", ->
         keydown('j')
-        expect(editor.getCursorScreenPosition()).toEqual [2, 1]
+        expect(editor.getCursorBufferPosition()).toEqual [2, 1]
 
         keydown('j')
-        expect(editor.getCursorScreenPosition()).toEqual [2, 1]
+        expect(editor.getCursorBufferPosition()).toEqual [2, 1]
 
     describe "the k keybinding", ->
       it "moves the cursor up, but not to the beginning of the first line", ->
         keydown('k')
-        expect(editor.getCursorScreenPosition()).toEqual [0, 1]
+        expect(editor.getCursorBufferPosition()).toEqual [0, 1]
 
         keydown('k')
-        expect(editor.getCursorScreenPosition()).toEqual [0, 1]
+        expect(editor.getCursorBufferPosition()).toEqual [0, 1]
 
     describe "the l keybinding", ->
       beforeEach -> editor.setCursorScreenPosition([1, 3])
 
       it "moves the cursor right, but not to the next line", ->
         keydown('l')
-        expect(editor.getCursorScreenPosition()).toEqual [1, 4]
+        expect(editor.getCursorBufferPosition()).toEqual [1, 4]
 
         keydown('l')
-        expect(editor.getCursorScreenPosition()).toEqual [1, 4]
+        expect(editor.getCursorBufferPosition()).toEqual [1, 4]
 
   describe "the w keybinding", ->
     beforeEach -> editor.setText("ab cde1+- \n xyz\n\nzip")


### PR DESCRIPTION
It's bug when moving down or right there may be some errors if you enable the softwrap option.
For example if I have code like below, then I can't move below or right:
![motions_coffee_-__users_tony_github_vim-mode](https://f.cloud.github.com/assets/1253659/2355840/a0a21cd4-a5e1-11e3-91b2-6156db9d09dd.png)

btw, I notice that `#getCursorScreenPosition` is used at many places, maybe there're other errors, but I think we can fix them when we find the error.
