### PR TITLE
Treat ':' as cmd-shift-P in normal mode.

### DIFF
--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -119,4 +119,4 @@
   'ctrl-w v': 'pane:split-right'
   'ctrl-w ctrl-s': 'pane:split-down'
   'ctrl-w s': 'pane:split-down'
-  ':': 'fuzzy-finder:toggle-file-finder'
+  ':': 'command-palette:toggle'


### PR DESCRIPTION
This is idiomatic Vim, even if it doesn't match the semantics exactly: unless you plan on writing a full Vim script system for running on Atom, this may be the best hook for ':'.
