### PR TITLE
number+gg will jump to the (number+1) line

### DIFF
--- a/lib/motions.coffee
+++ b/lib/motions.coffee
@@ -339,8 +339,8 @@ class MoveToLastCharacterOfLine extends Motion
       true
 
 class MoveToStartOfFile extends MoveToLine
-  getDestinationRow: (count=0) ->
-    count
+  getDestinationRow: (count=1) ->
+    count - 1
 
 class MoveToTopOfScreen extends MoveToScreenLine
   getDestinationRow: (count=0) ->

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -426,7 +426,7 @@ describe "Motions", ->
 
   describe "the gg keybinding", ->
     beforeEach ->
-      editor.setText(" 1abc\n2\n3\n")
+      editor.setText(" 1abc\n 2\n3\n")
       editor.setCursorScreenPosition([0, 2])
 
     describe "as a motion", ->
@@ -436,6 +436,15 @@ describe "Motions", ->
 
       it "moves the cursor to the beginning of the first line", ->
         expect(editor.getCursorScreenPosition()).toEqual [0, 1]
+
+    describe "as a repeated motion", ->
+      beforeEach ->
+        keydown('2')
+        keydown('g')
+        keydown('g')
+
+      it "moves the cursor to a specified line", ->
+        expect(editor.getCursorScreenPosition()).toEqual [1, 1]
 
   describe "the G keybinding", ->
     beforeEach ->


### PR DESCRIPTION
I think this's a bug and can be fixed by changing these lines https://github.com/tony612/vim-mode/blob/show-cursor-just-in-focused-editor/lib/motions.coffee#L339..L341 to 

``` coffeescript
class MoveToStartOfFile extends MoveToLine
  getDestinationRow: (count=1) ->
    count - 1
```

Any idea?
