### PR TITLE
Don't throw errors on invalid regexes when searching

### DIFF
--- a/lib/search-view-model.coffee
+++ b/lib/search-view-model.coffee
@@ -74,7 +74,11 @@ class SearchViewModel
 
   scan: ->
     term = @searchTerm
-    regexp = new RegExp(term, 'g')
+    regexp = try
+               new RegExp(term, 'g')
+             catch
+               new RegExp(_.escapeRegExp(term), 'g')
+
     cur = @editor.getCursorBufferPosition()
     matchPoints = []
     iterator = (item) =>

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -572,6 +572,25 @@ describe "Motions", ->
 
         expect(editor.getCursorBufferPosition()).toEqual [1, 0]
 
+      it "uses a valid regex as a regex", ->
+        keydown('/')
+        # Cycle through the 'abc' on the first line with a character pattern
+        editor.commandModeInputView.editor.setText '[abc]'
+        editor.commandModeInputView.editor.trigger 'core:confirm'
+        expect(editor.getCursorBufferPosition()).toEqual [0, 1]
+        keydown('n')
+        expect(editor.getCursorBufferPosition()).toEqual [0, 2]
+
+      it "uses an invalid regex as a literal string", ->
+        # Go straight to the literal [abc
+        editor.setText("abc\n[abc]\n")
+        keydown('/')
+        editor.commandModeInputView.editor.setText '[abc'
+        editor.commandModeInputView.editor.trigger 'core:confirm'
+        expect(editor.getCursorBufferPosition()).toEqual [1, 0]
+        keydown('n')
+        expect(editor.getCursorBufferPosition()).toEqual [1, 0]
+
       describe "repeating", ->
         it "does nothing with no search history", ->
           # This tests that no exception is raised


### PR DESCRIPTION
Try searching for `(c`. We currently raise and show the console. Vim's behavior is to interpret valid regexes\* as such and invalid ones as literal strings. We now match that behavior.
- Okay, [goofy not-quite-regex search patterns](http://vimdoc.sourceforge.net/htmldoc/pattern.html), but whatever.
