### PR TITLE
README: fix TODO and doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ them useful as no one person uses all of vim's functionality.
 ### Future Work (in rough order)
 
 * Visual mode
-  * ~~Characterwise~~
-  * ~~Linewise~~
   * Blockwise
 * Support for marks (including \`.)
 * Support for `q` and `.`


### PR DESCRIPTION
Removed completed items from "Future Work" and fixed a doc link to the pane split commands.
