### PR TITLE
Make block cursor cover character underneath it

### DIFF
--- a/stylesheets/vim-mode.less
+++ b/stylesheets/vim-mode.less
@@ -7,6 +7,10 @@
   opacity: 0.5;
 }
 
+.cursor .chr {
+  visibility: hidden;
+}
+
 .vim-mode.command-mode, .vim-mode.operator-pending-mode {
   .cursor, .cursor.blink-off {
     .block-cursor(hidden);


### PR DESCRIPTION
The block cursor does not completely cover characters that are wider than a non-breaking space (the width is set at one single `"&nbsp;"`), such as CJK characters.

This change updates the `CursorView` with the character under the cursor whenever it moves (i.e., "cursor:moved").
-  CJK Character
  -  Before: ![image](https://f.cloud.github.com/assets/189989/2460955/d4844204-af71-11e3-9a48-da85b2474e39.png)
  -  After: ![image](https://f.cloud.github.com/assets/189989/2460996/390aa7fe-af72-11e3-9ac4-3ffe93523c3e.png)
-  Tab
  -  Before: ![image](https://f.cloud.github.com/assets/189989/2461189/6e0b44ca-af74-11e3-8f77-5a3db21c7dcc.png)
  -  After: ![image](https://f.cloud.github.com/assets/189989/2461183/56305ce6-af74-11e3-985a-ddc437efae2a.png)

I'm not quite sure how to write the specs for this, though...
