### PR TITLE
Fix paste operation bug when cursor is on last line.

### DIFF
--- a/lib/operators/put-operator.coffee
+++ b/lib/operators/put-operator.coffee
@@ -40,7 +40,7 @@ class Put extends Operator
 
     textToInsert = _.times(count, -> text).join('')
     if @location == 'after' and type == 'linewise' and @onLastRow()
-      textToInsert = "\n#{textToInsert.substring(0, textToInsert.length - 1)}"
+      textToInsert = "\n#{textToInsert}"
     @editor.insertText(textToInsert)
 
     if originalPosition?

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -375,7 +375,7 @@ describe "Operators", ->
         keydown('p')
 
       it "inserts the contents of the default register", ->
-        expect(editor.getText()).toBe "012\n 345"
+        expect(editor.getText()).toBe "012\n 345\n"
         expect(editor.getCursorScreenPosition()).toEqual [1, 1]
 
     describe "with multiple linewise contents", ->
@@ -386,7 +386,7 @@ describe "Operators", ->
         keydown('p')
 
       it "inserts the contents of the default register", ->
-        expect(editor.getText()).toBe "012\nabc\n 345\n 678"
+        expect(editor.getText()).toBe "012\nabc\n 345\n 678\n"
         expect(editor.getCursorScreenPosition()).toEqual [2, 1]
 
     describe "pasting twice", ->


### PR DESCRIPTION
Fixes #195. Can't work out what the intention behind removing the last character was, but everything works fine with this change.
