### PR TITLE
Move common Search motion behavior to SearchBase class

### DIFF
--- a/lib/motions/index.coffee
+++ b/lib/motions/index.coffee
@@ -1,5 +1,5 @@
 Motions = require './general-motions'
-Search = require './search-motion'
+{Search} = require './search-motion'
 MoveToMark = require './move-to-mark-motion'
 Find = require './find-motion'
 

--- a/lib/motions/search-motion.coffee
+++ b/lib/motions/search-motion.coffee
@@ -2,18 +2,12 @@ _ = require 'underscore-plus'
 {MotionWithInput} = require './general-motions'
 SearchViewModel = require '../view-models/search-view-model'
 
-module.exports =
-class Search extends MotionWithInput
+class SearchBase extends MotionWithInput
   @currentSearch: null
   constructor: (@editorView, @vimState) ->
     super(@editorView, @vimState)
-    @viewModel = new SearchViewModel(@)
     Search.currentSearch = @
     @reverse = @initiallyReversed = false
-
-  compose: (input) ->
-    super(input)
-    @viewModel.value = @input.characters
 
   repeat: (opts = {}) =>
     reverse = opts.backwards
@@ -72,3 +66,16 @@ class Search extends MotionWithInput
     after = after.reverse() if @reverse
 
     @matches = after
+
+class Search extends SearchBase
+  constructor: (@editorView, @vimState) ->
+    super(@editorView, @vimState)
+    @viewModel = new SearchViewModel(@)
+    Search.currentSearch = @
+    @reverse = @initiallyReversed = false
+
+  compose: (input) ->
+    super(input)
+    @viewModel.value = @input.characters
+
+module.exports = {Search}


### PR DESCRIPTION
Create common SearchBase class that will hold the common Search logic for different Search strategies (Search with View, Search with current word, etc).

Related to PR #197
