### PR TITLE
add motion: double ` for going back to previous position

### DIFF
--- a/lib/motions/move-to-mark-motion.coffee
+++ b/lib/motions/move-to-mark-motion.coffee
@@ -12,6 +12,11 @@ class MoveToMark extends MotionWithInput
 
   execute: ->
     markPosition = @vimState.getMark(@input.characters)
+
+    if @input.characters == '`' # double '`' pressed
+      markPosition ?= [0, 0] # if markPosition not set, go to the beginning of the file
+      @vimState.setMark('`', @editorView.editor.getCursorBufferPosition())
+
     @editor.setCursorBufferPosition(markPosition) if markPosition?
     if @linewise
       @editorView.trigger 'vim-mode:move-to-first-character-of-line'

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -278,12 +278,12 @@ class VimState
   # Private: Sets the value of a given mark.
   #
   # name  - The name of the mark to fetch.
-  # value {Point} - The value to set the mark to.
+  # pos {Point} - The value to set the mark to.
   #
   # Returns nothing.
   setMark: (name, pos) ->
-    # check to make sure name is in [a-z]
-    if (charCode = name.charCodeAt(0)) >= 97 and charCode <= 122
+    # check to make sure name is in [a-z] or is `
+    if (charCode = name.charCodeAt(0)) >= 96 and charCode <= 122
       @marks[name] = pos
 
   # Public: Append a search to the search history.

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -904,6 +904,15 @@ describe "Motions", ->
       commandModeInputKeydown('a')
       expect(editor.getText()).toEqual '  12\n    36\n'
 
+    it 'moves back to previous', ->
+      editor.setCursorBufferPosition([1,5])
+      keydown('`')
+      commandModeInputKeydown('`')
+      editor.setCursorBufferPosition([2,1])
+      keydown('`')
+      commandModeInputKeydown('`')
+      expect(editor.getCursorBufferPosition()).toEqual [1,5]
+      
 
   describe 'the f/F keybindings', ->
     beforeEach ->
@@ -969,32 +978,32 @@ describe "Motions", ->
       keydown('T', shift: true)
       commandModeInputKeydown('a')
       expect(editor.getCursorScreenPosition()).toEqual [0, 1]
-  
+
     it 'respects count forward', ->
       keydown('2')
       keydown('t')
       commandModeInputKeydown('a')
       expect(editor.getCursorScreenPosition()).toEqual [0, 5]
-  
+
     it 'respects count backward', ->
       editor.setCursorScreenPosition([0, 6])
       keydown('2')
       keydown('T', shift: true)
       commandModeInputKeydown('a')
       expect(editor.getCursorScreenPosition()).toEqual [0, 1]
-  
+
     it "doesn't move if the character specified isn't found", ->
       keydown('t')
       commandModeInputKeydown('d')
       expect(editor.getCursorScreenPosition()).toEqual [0, 0]
-  
+
     it "doesn't move if there aren't the specified count of the specified character", ->
       keydown('1')
       keydown('0')
       keydown('t')
       commandModeInputKeydown('a')
       expect(editor.getCursorScreenPosition()).toEqual [0, 0]
-  
+
     it "composes with d", ->
       editor.setCursorScreenPosition([0,3])
       keydown('d')
@@ -1002,5 +1011,3 @@ describe "Motions", ->
       keydown('t')
       commandModeInputKeydown('a')
       expect(editor.getText()).toEqual 'abcabc\n'
-  
-


### PR DESCRIPTION
Previously pressing key "`" twice did not go to previous position. This feature has been added and now it behaves the same as in official vim.

Also, in the previous version marks supported only a-z but in official vim the key "`" is also supported. And this has been added by allowing keycode 96 as a mark.

Corresponding specs have been added.
