### PR TITLE
Fix "end of line movement" not on last character 

### DIFF
--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -380,8 +380,7 @@ class MoveToLastCharacterOfLine extends Motion
   execute: (count=1) ->
     _.times count, =>
       @editor.moveCursorToEndOfLine()
-      if @editor.getCursor().getBufferColumn() isnt 0
-          @editor.moveCursorLeft()
+      @editor.moveCursorLeft() unless @editor.getCursor().getBufferColumn() is 0
 
   select: (count=1) ->
     _.times count, =>

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -499,14 +499,14 @@ describe "Motions", ->
       beforeEach -> editor.setCursorScreenPosition([1, 0])
 
       it "moves the cursor to the end of the line", ->
-        expect(editor.getCursorScreenPosition()).toEqual {row:1, column:0}
+        expect(editor.getCursorScreenPosition()).toEqual [1, 0]
 
     describe "as a motion", ->
       beforeEach -> keydown('$')
 
       # FIXME: See atom/vim-mode#2
       it "moves the cursor to the end of the line", ->
-        expect(editor.getCursorScreenPosition()).toEqual {row:0, column:6}
+        expect(editor.getCursorScreenPosition()).toEqual [0, 6]
 
     describe "as a selection", ->
       beforeEach ->
@@ -515,7 +515,7 @@ describe "Motions", ->
 
       it "selects to the beginning of the lines", ->
         expect(editor.getText()).toBe "  ab\n\n"
-        expect(editor.getCursorScreenPosition()).toEqual {row:0, column:3}
+        expect(editor.getCursorScreenPosition()).toEqual [0, 3]
 
   # FIXME: this doesn't work as we can't determine if this is a motion
   # or part of a repeat prefix.


### PR DESCRIPTION
This PR is a fix for issue #245.

`Vim Mode: Move To Last Character Of Line` is now:
![screenshot from 2014-05-15 20 03 07](https://cloud.githubusercontent.com/assets/102641/2992906/8c3f3c1a-dc9e-11e3-842b-b3a6d39394c4.png)

(BTW, this is my fist PR ever!)
