### PR TITLE
Allow colon or semi-colon to open command palette, similar to vim's command line

### DIFF
--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -97,6 +97,8 @@
   '#': 'vim-mode:reverse-search-current-word'
   'n': 'vim-mode:repeat-search'
   'N': 'vim-mode:repeat-search-backwards'
+  ';': 'command-palette:toggle'
+  ':': 'command-palette:toggle'
 
   '1': 'vim-mode:repeat-prefix'
   '2': 'vim-mode:repeat-prefix'


### PR DESCRIPTION
I don't know if there's plans on implementing vim's command line, but this is convenient enough just for the time being.  The command-palette is fairly analogous to vim's command line anyway. 
