### PR TITLE
Make keyCode undefined when 0

### DIFF
--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -30,6 +30,8 @@ keydown = (key, {element, ctrl, shift, alt, meta, raw}={}) ->
   dispatchKeyboardEvent = (target, eventArgs...) ->
     e = document.createEvent('KeyboardEvent')
     e.initKeyboardEvent eventArgs...
+    # 0 is the default, and it's valid ASCII, but it's wrong.
+    Object.defineProperty(e, 'keyCode', get: -> undefined) if e.keyCode is 0
     target.dispatchEvent e
 
   dispatchTextEvent = (target, eventArgs...) ->


### PR DESCRIPTION
0 is the default but it should really be undefined since the null key wasn't actually pressed.

This was ported over from atom/atom-keymap which recently changed how it handles keyCode/keyIdentifer in https://github.com/atom/atom-keymap/pull/22
