### PR TITLE
Bump atom req to one with a fixed keymap

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "repository": "https://github.com/atom/vim-mode",
   "engines": {
-    "atom": ">0.98.0"
+    "atom": ">0.99.0"
   },
   "dependencies": {
     "underscore-plus": "1.x"


### PR DESCRIPTION
This bumps vim-mode's atom requirement to one with a fixed keymap that seems to fix a ton of open issues.

cc @kevinsawicki do I need anything else on the vim-mode side?

@jacobgardner can you make sure this branch still works on linux with the latest atom release? Everything should be 100% now.

@mcnicholls tests should be passing on this branch in win32 and I would :heart: if you could check. I imagine your pull is ready to go without further changes after this lands.
