### PR TITLE
Fixes visual mode selection for G and gg

### DIFF
--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -320,7 +320,7 @@ class MoveToLine extends Motion
 
   # Options
   #  requireEOL - if true, ensure an end of line character is always selected
-  select: (count=1, {requireEOL}={}) ->
+  select: (count=@editor.getLineCount(), {requireEOL}={}) ->
     {row, column} = @editor.getCursorBufferPosition()
     @editor.setSelectedBufferRange(@selectRows(row, row + (count - 1), requireEOL: requireEOL))
 
@@ -401,6 +401,11 @@ class MoveToLastCharacterOfLine extends Motion
 class MoveToStartOfFile extends MoveToLine
   getDestinationRow: (count=1) ->
     count - 1
+
+  select: (count=1) ->
+    {row, column} = @editor.getCursorBufferPosition()
+    bufferRange = new Range([row,column+1], [0,0])
+    @editor.setSelectedBufferRange(bufferRange, reversed: true)
 
 class MoveToTopOfScreen extends MoveToScreenLine
   getDestinationRow: (count=0) ->

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -556,6 +556,19 @@ describe "Motions", ->
       it "moves the cursor to a specified line", ->
         expect(editor.getCursorScreenPosition()).toEqual [1, 1]
 
+    describe "as a selection", ->
+      beforeEach ->
+        editor.setCursorScreenPosition([1, 1])
+        vimState.activateVisualMode()
+        keydown('g')
+        keydown('g')
+
+      it "selects to the first line in the file", ->
+        expect(editor.getSelectedText()).toBe " 1abc\n 2"
+
+      it "moves the cursor to a specified line", ->
+        expect(editor.getCursorScreenPosition()).toEqual [0, 0]
+
   describe "the G keybinding", ->
     beforeEach ->
       editor.setText("1\n    2\n 3abc\n ")
@@ -574,6 +587,18 @@ describe "Motions", ->
 
       it "moves the cursor to a specified line", ->
         expect(editor.getCursorScreenPosition()).toEqual [1, 4]
+
+    describe "as a selection", ->
+      beforeEach ->
+        editor.setCursorScreenPosition([1, 0])
+        vimState.activateVisualMode()
+        keydown('G', shift: true)
+
+      it "selects to the last line in the file", ->
+        expect(editor.getSelectedText()).toBe "    2\n 3abc\n "
+
+      it "moves the cursor to the last line after whitespace", ->
+        expect(editor.getCursorScreenPosition()).toEqual [3,1]
 
   describe "the / keybinding", ->
     beforeEach ->


### PR DESCRIPTION
MoveToLine's G selection code previously only moved a single line down,
which is not in line with vim.  MoveToStartOfFile was also only moving
a single line of code in selection mode.  This corrects both of these
selection issues.

![g_selection](https://cloud.githubusercontent.com/assets/28146/3076226/b752d1f8-e3c1-11e3-9e71-153a43f9853d.gif)
