### PR TITLE
Remove text shadow and use correct variable for mini-editor

### DIFF
--- a/stylesheets/vim-mode.less
+++ b/stylesheets/vim-mode.less
@@ -1,4 +1,5 @@
 @import "syntax-variables";
+@import "ui-variables";
 
 .block-cursor(@visibility: visible) {
   border: 0;
@@ -30,8 +31,7 @@
   border: none;
   width: 100%;
   font-weight: normal;
-  color: #aaaaaa;
-  text-shadow: 0 -1px 0 #333333;
+  color: @text-color;
   // see also the commandModeInputViewFontSize setting.
   line-height: 1.28;
   cursor: default;


### PR DESCRIPTION
Fixes #196. I was using the wrong less variable for the text color, which required I add a text shadow to make it visible in atom-dark. It's not needed so much when I use the right variable, so I just removed the shadow so it starts looking cool in atom-light as well.
