### PR TITLE
Changes to fix the problem when xpp is typed.

### DIFF
--- a/lib/operators/put-operator.coffee
+++ b/lib/operators/put-operator.coffee
@@ -55,6 +55,8 @@ class Put extends Operator
       @editor.moveCursorToFirstCharacterOfLine()
 
     @vimState.activateCommandMode()
+    if type != 'linewise'
+      @editor.moveCursorLeft()
 
   # Private: Helper to determine if the editor is currently on the last row.
   #

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -382,7 +382,7 @@ describe "Operators", ->
 
         it "inserts the contents", ->
           expect(editor.getText()).toBe "034512\n"
-          expect(editor.getCursorScreenPosition()).toEqual [0, 4]
+          expect(editor.getCursorScreenPosition()).toEqual [0, 3]
 
       describe "from a specified register", ->
         beforeEach ->
@@ -392,7 +392,7 @@ describe "Operators", ->
 
         it "inserts the contents of the 'a' register", ->
           expect(editor.getText()).toBe "0a12\n"
-          expect(editor.getCursorScreenPosition()).toEqual [0, 2]
+          expect(editor.getCursorScreenPosition()).toEqual [0, 1]
 
       describe "at the end of a line", ->
         it "inserts before the current line's newline", ->
@@ -481,7 +481,7 @@ describe "Operators", ->
 
       it "inserts the contents of the default register above", ->
         expect(editor.getText()).toBe "345012\n"
-        expect(editor.getCursorScreenPosition()).toEqual [0, 3]
+        expect(editor.getCursorScreenPosition()).toEqual [0, 2]
 
   describe "the O keybinding", ->
     beforeEach ->


### PR DESCRIPTION
When you type `abcdef` and then stand on the `b` and type `xpp` the text should become `acbbdef` with the cursor on the last `b`. Instead it becomes: `acbdbef` with the cursor on the `e`. The attached pull request solves this problem.
