### PR TITLE
Add move-to-next-char feature using the default "space" binding

### DIFF
--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -9,6 +9,7 @@
   'backspace': 'core:move-left'
   'l': 'vim-mode:move-right'
   'right': 'vim-mode:move-right'
+  'space': 'vim-mode:move-to-next-char'
   'k': 'vim-mode:move-up'
   'up': 'vim-mode:move-up'
   'j': 'vim-mode:move-down'

--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -94,6 +94,24 @@ class MoveDown extends Motion
       @editor.selectDown()
       true
 
+class MoveToNextChar extends Motion
+  execute: (count=1) ->
+    _.times count, =>
+      {row, column} = @editor.getCursorScreenPosition()
+      buffer = @editor.getBuffer()
+      lastRow = buffer.getLastRow()
+      lastCharIndex = buffer.lineForRow(row).length - 1
+      if column < lastCharIndex
+        @editor.moveCursorRight()
+      else if row isnt lastRow
+        @editor.moveCursorDown()
+        @editor.moveCursorToBeginningOfLine()
+
+  select: (count=1) ->
+    _.times count, =>
+      @editor.selectRight()
+      return true
+
 class MoveToPreviousWord extends Motion
   execute: (count=1) ->
     _.times count, =>
@@ -436,7 +454,7 @@ class MoveToMiddleOfScreen extends MoveToScreenLine
 
 module.exports = {
   Motion, MotionWithInput, CurrentSelection, MoveLeft, MoveRight, MoveUp, MoveDown,
-  MoveToPreviousWord, MoveToPreviousWholeWord, MoveToNextWord, MoveToNextWholeWord,
+  MoveToNextChar, MoveToPreviousWord, MoveToPreviousWholeWord, MoveToNextWord, MoveToNextWholeWord,
   MoveToEndOfWord, MoveToNextParagraph, MoveToPreviousParagraph, MoveToLine, MoveToBeginningOfLine,
   MoveToFirstCharacterOfLine, MoveToLastCharacterOfLine, MoveToStartOfFile, MoveToTopOfScreen,
   MoveToBottomOfScreen, MoveToMiddleOfScreen, MoveToEndOfWholeWord, MotionError

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -122,6 +122,7 @@ class VimState
       'move-up': => new Motions.MoveUp(@editor, @)
       'move-down': => new Motions.MoveDown(@editor, @)
       'move-right': => new Motions.MoveRight(@editor, @)
+      'move-to-next-char': => new Motions.MoveToNextChar(@editor)
       'move-to-next-word': => new Motions.MoveToNextWord(@editor)
       'move-to-next-whole-word': => new Motions.MoveToNextWholeWord(@editor)
       'move-to-end-of-word': => new Motions.MoveToEndOfWord(@editor)

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -71,6 +71,63 @@ describe "Motions", ->
         keydown('l')
         expect(editor.getCursorScreenPosition()).toEqual [1, 4]
 
+    describe "the space keybinding", ->
+      beforeEach -> editor.setCursorScreenPosition([1, 3])
+
+      describe "as a motion", ->
+
+        it "moves the cursor right and can go to the next line", ->
+          keydown(' ')
+          expect(editor.getCursorScreenPosition()).toEqual [1, 4]
+
+          keydown(' ')
+          expect(editor.getCursorScreenPosition()).toEqual [2, 0]
+
+          keydown(' ')
+          expect(editor.getCursorScreenPosition()).toEqual [2, 1]
+
+        it "stops moving the cursor if its reached the last row and before the last column", ->
+          editor.setCursorScreenPosition([2, 4])
+
+          keydown(' ')
+          expect(editor.getCursorScreenPosition()).toEqual [2, 4]
+
+          keydown(' ')
+          expect(editor.getCursorScreenPosition()).toEqual [2, 4]
+
+      describe "as a selection", ->
+        beforeEach -> keydown('v')
+
+        it "selects the character to right and can select up to the next line", ->
+          keydown(' ')
+          expect(editor.getSelectedText()).toEqual("d")
+
+          keydown(' ')
+          expect(editor.getSelectedText()).toEqual("de")
+
+          keydown(' ')
+          expect(editor.getSelectedText()).toEqual("de\n")
+
+          keydown(' ')
+          expect(editor.getSelectedText()).toEqual("de\nA")
+
+          keydown(' ')
+          expect(editor.getSelectedText()).toEqual("de\nAB")
+
+        it "selects the character at the last column of the last row and stops", ->
+          editor.setCursorScreenPosition([2, 4])
+          keydown('v')
+
+          # FIXME: this isn't the correct behavior since going into
+          # visual characterwise mode currently doesnt select the character
+          # right away. pressing 'v' should have selected it right away
+          # without having to press space one.
+          keydown(' ')
+          expect(editor.getSelectedText()).toEqual("E")
+
+          keydown(' ')
+          expect(editor.getSelectedText()).toEqual("E")
+
   describe "the w keybinding", ->
     beforeEach -> editor.setText("ab cde1+- \n xyz\n\nzip")
 


### PR DESCRIPTION
this is different from "move-right" which does not move to the next
line.
