### PR TITLE
Make vim-mode keymaps more specific to override certain OS mappings

### DIFF
--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -1,9 +1,9 @@
-'.vim-mode:not(.command-mode)':
+'.editor.vim-mode:not(.command-mode)':
   'escape': 'vim-mode:activate-command-mode'
   'ctrl-c': 'vim-mode:activate-command-mode'
   'ctrl-[': 'vim-mode:activate-command-mode'
 
-'.vim-mode:not(.insert-mode)':
+'.editor.vim-mode:not(.insert-mode)':
   'h': 'vim-mode:move-left'
   'left': 'vim-mode:move-left'
   'backspace': 'core:move-left'
@@ -110,7 +110,7 @@
   '8': 'vim-mode:repeat-prefix'
   '9': 'vim-mode:repeat-prefix'
 
-'.vim-mode.command-mode':
+'.editor.vim-mode.command-mode':
   'i': 'vim-mode:activate-insert-mode'
   'v': 'vim-mode:activate-characterwise-visual-mode'
   'V': 'vim-mode:activate-linewise-visual-mode'
@@ -166,9 +166,9 @@
   '" %': 'vim-mode:register-prefix'
   '" _': 'vim-mode:register-prefix'
 
-'.vim-mode.operator-pending-mode, .vim-mode.visual-mode':
+'.editor.vim-mode.operator-pending-mode, .editor.vim-mode.visual-mode':
   'i w': 'vim-mode:select-inside-word'
 
-'.vim-mode.visual-mode':
+'.editor.vim-mode.visual-mode':
   'x': 'vim-mode:delete'
   's': 'vim-mode:change'


### PR DESCRIPTION
Let me try this one again...

The specific example is Ctrl-[.
On win32 this is mapped to another action because the selector is more specific.

Making the vim-mode selectors more specific will override the defaults.

fixes #263
