### PR TITLE
Fix off-by-one errors involving <CR>, j and k

### DIFF
--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -79,6 +79,7 @@ class MoveUp extends Motion
       @editor.moveCursorUp() if row > 0
 
   select: (count=1) ->
+    @editor.selectLine()
     _.times count, =>
       @editor.selectUp()
       true
@@ -90,6 +91,7 @@ class MoveDown extends Motion
       @editor.moveCursorDown() if row < (@editor.getBuffer().getLineCount() - 1)
 
   select: (count=1) ->
+    @editor.selectLine()
     _.times count, =>
       @editor.selectDown()
       true


### PR DESCRIPTION
This patch fixes #191 and #51.

I'll be using as example yank, but I confirm the same behavior with
delete and replace.

After experimenting a bit with vim and atom, I noticed that when yanking
thee lines with the cursor on the middle of a paragraph with `y2j` on
vim, it copied the three lines. This is not true for vim-mode - it was
copying one line partially.

I linked this with the off-by-one errors, and got to the conclusion that
finishing commands using <CR>, j, k, down arrow and up arrow selects all
the current line apart from <n> lines on the top/bottom of the current
one.

This is actually a really simple fix. It didn't break any test. I would
like to add some tests for this, but I didn't find myself very well on
the tests code. I can't find where selections are being tested, if any.
