### PR TITLE
Fix off-by-one errors, with tests

### DIFF
--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -10,6 +10,7 @@ class Motion
 
   isComplete: -> true
   isRecordable: -> false
+  inVisualMode: -> @vimState.mode == "visual"
 
 class CurrentSelection extends Motion
   execute: (count=1) ->
@@ -79,6 +80,11 @@ class MoveUp extends Motion
       @editor.moveCursorUp() if row > 0
 
   select: (count=1) ->
+    unless @inVisualMode()
+      @editor.moveCursorToBeginningOfLine()
+      @editor.moveCursorDown()
+      @editor.selectUp()
+
     _.times count, =>
       @editor.selectUp()
       true
@@ -90,6 +96,7 @@ class MoveDown extends Motion
       @editor.moveCursorDown() if row < (@editor.getBuffer().getLineCount() - 1)
 
   select: (count=1) ->
+    @editor.selectLine() unless @inVisualMode()
     _.times count, =>
       @editor.selectDown()
       true

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -53,6 +53,23 @@ describe "Motions", ->
         keydown('j')
         expect(editor.getCursorScreenPosition()).toEqual [2, 1]
 
+      describe "when visual mode", ->
+        beforeEach ->
+          keydown('v')
+
+        it "moves the cursor down", ->
+          keydown('j')
+          expect(editor.getCursorScreenPosition()).toEqual [2, 1]
+
+        it "don't go over after the last line", ->
+          keydown('j')
+          expect(editor.getCursorScreenPosition()).toEqual [2, 1]
+
+        it "selects the text while moving", ->
+          keydown('j')
+          expect(editor.getSelectedText()).toBe "bcde\nA"
+
+
     describe "the k keybinding", ->
       it "moves the cursor up, but not to the beginning of the first line", ->
         keydown('k')

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -257,6 +257,59 @@ describe "Operators", ->
         expect(editorView).not.toHaveClass('operator-pending-mode')
         expect(editorView).toHaveClass('command-mode')
 
+    describe "when followed by an j", ->
+      beforeEach ->
+        originalText = "12345\nabcde\nABCDE"
+        editor.setText(originalText)
+
+        describe "on the beginning of the file", ->
+          editor.setCursorScreenPosition([0, 0])
+          it "deletes the next two lines", ->
+            keydown('d')
+            keydown('j')
+            expect(editor.getText()).toBe("ABCDE")
+
+        describe "on the end of the file", ->
+          editor.setCursorScreenPosition([4,2])
+          it "deletes nothing", ->
+            keydown('d')
+            keydown('j')
+            expect(editor.getText()).toBe(originalText)
+
+        describe "on the middle of second line", ->
+          editor.setCursorScreenPosition([2,1])
+          it "deletes the last two lines", ->
+            keydown('d')
+            keydown('j')
+            expect(editor.getText()).toBe("12345")
+
+    describe "when followed by an k", ->
+      beforeEach ->
+        originalText = "12345\nabcde\nABCDE"
+        editor.setText(originalText)
+
+        describe "on the end of the file", ->
+          editor.setCursorScreenPosition([4, 2])
+          it "deletes the bottom two lines", ->
+            keydown('d')
+            keydown('k')
+            expect(editor.getText()).toBe("ABCDE")
+
+        describe "on the beginning of the file", ->
+          editor.setCursorScreenPosition([0,0])
+          it "deletes nothing", ->
+            keydown('d')
+            keydown('k')
+            expect(editor.getText()).toBe(originalText)
+
+        describe "when on the middle of second line", ->
+          editor.setCursorScreenPosition([2,1])
+          it "deletes the first two lines", ->
+            keydown('d')
+            keydown('k')
+            expect(editor.getText()).toBe("12345")
+
+
   describe "the D keybinding", ->
     beforeEach ->
       editor.getBuffer().setText("012\n")


### PR DESCRIPTION
This patch fixes #191 and #51.

I'll be using as example yank, but I confirm the same behavior with
delete and replace.

After experimenting a bit with vim and atom, I noticed that when yanking
thee lines with the cursor on the middle of a paragraph with y2j on
vim, it copied the three lines. This is not true for vim-mode - it was
copying one line partially.

I linked this with the off-by-one errors, and got to the conclusion that
finishing commands using , j, k, down arrow and up arrow selects all
the current line apart from lines on the top/bottom of the current
one.

I wrote some tests, hopefuly in the correct palce. I'm a bit off in
where to put the tests.
