### PR TITLE
Use ::setInputEnabled to disable input outside of insert mode for the React editor

### DIFF
--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -30,6 +30,7 @@ class VimState
     params.id = 0;
 
     @setupCommandMode()
+    @editorView.setInputEnabled?(false)
     @registerInsertIntercept()
     @registerInsertTransactionResets()
     if atom.config.get 'vim-mode.startInInsertMode'
@@ -364,6 +365,7 @@ class VimState
   # Returns nothing.
   activateInsertMode: (transactionStarted = false)->
     @mode = 'insert'
+    @editorView.setInputEnabled?(true)
     @editor.beginTransaction() unless transactionStarted
     @submode = null
     @changeModeClass('insert-mode')
@@ -371,6 +373,7 @@ class VimState
 
   deactivateInsertMode: ->
     return unless @mode == 'insert'
+    @editorView.setInputEnabled?(false)
     @editor.commitTransaction()
     transaction = _.last(@editor.buffer.history.undoStack)
     item = @inputOperator(@history[0])


### PR DESCRIPTION
The approach of preempting textinput events to prevent handling of input
outside of insert mode doesn't mesh well with the new React editor
because we don't use jQuery to process input events. I added an explicit
API for disabling input in atom/atom@64870c733, which is used here if
available. We retain the old interception approach for the time being
for compatibility with the existing editor.
