### PR TITLE
:bug:Fix delete with 'G' motions

### DIFF
--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -402,7 +402,12 @@ class MoveToLine extends Motion
   #  requireEOL - if true, ensure an end of line character is always selected
   select: (count=@editor.getLineCount(), {requireEOL}={}) ->
     {row, column} = @editor.getCursorBufferPosition()
-    @editor.setSelectedBufferRange(@selectRows(row, row + (count - 1), requireEOL: requireEOL))
+    min = row
+    max = count - 1;
+    if (min > max)
+        min = max
+        max = row
+    @editor.setSelectedBufferRange(@selectRows(min, max, requireEOL: requireEOL))
 
     _.times count, ->
       true

--- a/lib/operators/general-operators.coffee
+++ b/lib/operators/general-operators.coffee
@@ -83,7 +83,7 @@ class Delete extends Operator
   # count - The number of times to execute.
   #
   # Returns nothing.
-  execute: (count=1) ->
+  execute: (count) ->
     cursor = @editor.getCursor()
 
     if _.contains(@motion.select(count, @selectOptions), true)


### PR DESCRIPTION
This is an attempt at fixing #325.
The changes fixes delete with the G motions, but it breaks some specs.
What do you guys think?

dG from line 4 (eof)
![dv-dg](https://cloud.githubusercontent.com/assets/2568174/3422302/0b548f06-ff2b-11e3-8df9-3b8c0150adfe.gif)

d2G from line 4 (backward)
![dv-d2g](https://cloud.githubusercontent.com/assets/2568174/3422299/0b4f3484-ff2b-11e3-9e79-a39b3e7d32c0.gif)

d6G from line 4 (forward)
![dv-d6g](https://cloud.githubusercontent.com/assets/2568174/3422300/0b533b24-ff2b-11e3-8268-ed99ef92a80b.gif)

d4G from line 4 (same line)
![dv-d4g](https://cloud.githubusercontent.com/assets/2568174/3422301/0b53884a-ff2b-11e3-9bc7-af4e3a71c70e.gif)
# Broken Specs
## Operators
- the d keybinding
  - when followed by a d
    - it deletes the current line and exits operator-pending mode
- the c binding
  - when followed by a c
    - it deletes the current line and enters insert mode
  - when the cursor is on the last line
    - it deletes the line's content and enters insert mode on the last line
- the > keybinding
  - on the last line
    - when followed by a >
      - it indents the current line
- the = keybinding
  - when used in a scope that supports auto-indent
    - when followed by a repeating =
      - it autoindents multiple lines at once
- the . keybinding
  - it composes with motions
## VimState
- marks
  - it real (tracking) marking functionality
