### PR TITLE
Revert "Ensure only one 'mode' is shown in the status bar"

### DIFF
--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -493,8 +493,7 @@ class VimState
   updateStatusBar: ->
     if !$('#status-bar-vim-mode').length
       atom.packages.once 'activated', ->
-        if !$('#status-bar-vim-mode').length
-          atom.workspaceView.statusBar?.prependRight("<div id='status-bar-vim-mode' class='inline-block'>Command</div>")
+        atom.workspaceView.statusBar?.prependRight("<div id='status-bar-vim-mode' class='inline-block'>Command</div>")
 
     if @mode is "insert"
       $('#status-bar-vim-mode').html("Insert")


### PR DESCRIPTION
Reverts atom/vim-mode#251

In preference to #302; I simply merged the wrong one.
