### PR TITLE
Fix for:  Motion commands not working with parentheses or brackets #336 

### DIFF
--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -176,8 +176,13 @@
   'i "': 'vim-mode:select-inside-double-quotes'
   'i \'': 'vim-mode:select-inside-single-quotes'
   'i {': 'vim-mode:select-inside-curly-brackets'
+  'i [': 'vim-mode:select-inside-square-brackets'
   'i <': 'vim-mode:select-inside-angle-brackets'
   'i (': 'vim-mode:select-inside-parentheses'
+  'i }': 'vim-mode:select-inside-curly-brackets'
+  'i ]': 'vim-mode:select-inside-square-brackets'
+  'i >': 'vim-mode:select-inside-angle-brackets'
+  'i )': 'vim-mode:select-inside-parentheses'
 
 '.editor.vim-mode.visual-mode':
   'x': 'vim-mode:delete'

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -161,6 +161,7 @@ class VimState
       'select-inside-double-quotes': => new TextObjects.SelectInsideQuotes(@editor, '"')
       'select-inside-single-quotes': => new TextObjects.SelectInsideQuotes(@editor, '\'')
       'select-inside-curly-brackets': => new TextObjects.SelectInsideBrackets(@editor, '{', '}')
+      'select-inside-square-brackets': => new TextObjects.SelectInsideBrackets(@editor, '[', ']')
       'select-inside-angle-brackets': => new TextObjects.SelectInsideBrackets(@editor, '<', '>')
       'select-inside-parentheses': => new TextObjects.SelectInsideBrackets(@editor, '(', ')')
       'register-prefix': (e) => @registerPrefix(e)


### PR DESCRIPTION
Added textobject for selecting square brackets. Added keybindings for selecting with closing brackets, and added keybindings for square brackets.
