### PR TITLE
Fix MoveRight when tabs are present

### DIFF
--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -58,10 +58,8 @@ class MoveRight extends Motion
   execute: (count=1) ->
     _.times count, =>
       {row, column} = @editor.getCursorScreenPosition()
-      lastCharIndex = @editor.getBuffer().lineForRow(row).length - 1
-
-      tabCount = @editor.getBuffer().lineForRow(row).split('\t').length
-      lastCharIndex += (tabCount * @editor.getTabLength())
+      bufferRange = @editor.bufferRangeForBufferRow(row)
+      lastCharIndex = @editor.screenRangeForBufferRange(bufferRange).end.column
 
       unless column >= lastCharIndex
         @editor.moveCursorRight()


### PR DESCRIPTION
Fixing a bug which occured when doing a MoveRight and tabs were present in the line. lineForRow counts tabs as a single char so the cursor does not move to the end of the line.

![recorded](https://cloud.githubusercontent.com/assets/1506585/3672237/1f3f99cc-125c-11e4-9ee4-fc77dc069733.gif)
