### PR TITLE
Fix MoveRight when tabs are present

### DIFF
--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -57,7 +57,7 @@ class MoveLeft extends Motion
 class MoveRight extends Motion
   execute: (count=1) ->
     _.times count, =>
-      {row, column} = @editor.getCursorScreenPosition()
+      {row, column} = @editor.getCursorBufferPosition()
       lastCharIndex = @editor.getBuffer().lineForRow(row).length - 1
       unless column >= lastCharIndex
         @editor.moveCursorRight()


### PR DESCRIPTION
While working with @rverton to do #353. According to @rverton, this change works in all cases.

[07:45] <foofoobar> The first solution you posted works as it should here, also on empty lines.
[07:45] <foofoobar> This one: http://hastebin.com/rurufusopa.coffee

> @rverton wrote in #353:
> Fixing a bug which occured when doing a MoveRight and tabs were present in the line. lineForRow counts tabs as a single char so the cursor does not move to the end of the line.
> ![](https://cloud.githubusercontent.com/assets/1506585/3672237/1f3f99cc-125c-11e4-9ee4-fc77dc069733.gif)

PS: I spent way too long on this.
