### PR TITLE
Don't store \n in register on 'o' or 'O'

### DIFF
--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -93,8 +93,7 @@ class VimState
   # Returns nothing.
   registerChangeHandler: (buffer) ->
     buffer.on 'changed', ({newRange, newText, oldRange, oldText}) =>
-      return unless @setRegister?
-      if newText == ''
+      if newText == '' and oldText != "\n"
         @setRegister('"', text: oldText, type: Utils.copyType(oldText))
 
   # Private: Creates the plugin's bindings

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -654,6 +654,16 @@ describe "Operators", ->
       keydown 'u'
       expect(editor.getText()).toBe "  abc\n  012\n"
 
+    it 'does not clear the " register', ->
+      editor.getBuffer().setText("abc\n\n012\n\ndef")
+      editor.setCursorScreenPosition([2, 0])
+      keydown('y')
+      keydown('y')
+      expect(vimState.getRegister('"').text).toBe "012\n"
+      keydown('O')
+      keydown 'escape'
+      expect(vimState.getRegister('"').text).toBe "012\n"
+
   describe "the o keybinding", ->
     beforeEach ->
       spyOn(editor, 'shouldAutoIndent').andReturn(true)
@@ -693,6 +703,15 @@ describe "Operators", ->
       keydown 'u'
       expect(editor.getText()).toBe "abc\n  012\n"
 
+    it 'does not clear the " register', ->
+      editor.getBuffer().setText("abc\n\n012\n\ndef")
+      editor.setCursorScreenPosition([2, 0])
+      keydown('y')
+      keydown('y')
+      expect(vimState.getRegister('"').text).toBe "012\n"
+      keydown('o')
+      keydown 'escape'
+      expect(vimState.getRegister('"').text).toBe "012\n"
 
   describe "the a keybinding", ->
     beforeEach ->


### PR DESCRIPTION
An 'o' or 'O' would cause a newline to be deleted and sent to the " register,
wiping out a prior yank. This would interfere with a common pattern of 'y, y,
<navigate to line>, o, p'
