### PR TITLE
Ensure yanked text ends with newline if motion is line-wise

### DIFF
--- a/lib/operators/general-operators.coffee
+++ b/lib/operators/general-operators.coffee
@@ -149,6 +149,9 @@ class Yank extends Operator
       text = ''
     type = if @motion.isLinewise?() then 'linewise' else 'character'
 
+    if @motion.isLinewise?() and text[-1..] isnt '\n'
+      text += '\n'
+
     @vimState.setRegister(@register, {text, type})
 
     if @motion.isLinewise?()

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -489,8 +489,17 @@ describe "Operators", ->
         keydown('y')
         keydown('p')
 
-        expect(vimState.getRegister('"').text).toBe "no newline!"
+        expect(vimState.getRegister('"').text).toBe "no newline!\n"
         expect(editor.getText()).toBe "no newline!\nno newline!"
+
+      it "copies the entire line and pastes it respecting count and new lines", ->
+        keydown('y')
+        keydown('y')
+        keydown('2')
+        keydown('p')
+
+        expect(vimState.getRegister('"').text).toBe "no newline!\n"
+        expect(editor.getText()).toBe "no newline!\nno newline!\nno newline!"
 
   describe "the Y keybinding", ->
     beforeEach ->


### PR DESCRIPTION
Add newline character to the register when the yanked line is the last line of the document and the motion is linewise.

Fixes the following situation:
- Yank a whole line `yy` at the last line of the document (**no newline after it**).
  ![a1](https://cloud.githubusercontent.com/assets/4009153/3683738/9f6a40ee-12ec-11e4-8f01-ee2cc2281fc1.png)
- Paste with count: `3p`
  ![a2](https://cloud.githubusercontent.com/assets/4009153/3683739/a2eddd16-12ec-11e4-9464-a89eb6237b44.png)

It should paste whole lines:
![a3](https://cloud.githubusercontent.com/assets/4009153/3683759/16bc324c-12ed-11e4-96c7-e0ce2d8a25d3.png)

It only happens when the yanked line has no line after it.

I've fixed it in the `yank` operation. Ensuring that the copied text has a '\n' at the end if the motion is line-wise.
