### PR TITLE
Add aliases for some text objects

### DIFF
--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -175,9 +175,17 @@
   'i w': 'vim-mode:select-inside-word'
   'i "': 'vim-mode:select-inside-double-quotes'
   'i \'': 'vim-mode:select-inside-single-quotes'
+
   'i {': 'vim-mode:select-inside-curly-brackets'
+  'i }': 'vim-mode:select-inside-curly-brackets'
+  'i B': 'vim-mode:select-inside-curly-brackets'
+
   'i <': 'vim-mode:select-inside-angle-brackets'
+  'i >': 'vim-mode:select-inside-angle-brackets'
+
   'i (': 'vim-mode:select-inside-parentheses'
+  'i )': 'vim-mode:select-inside-parentheses'
+  'i b': 'vim-mode:select-inside-parentheses'
 
 '.editor.vim-mode.visual-mode':
   'x': 'vim-mode:delete'

--- a/spec/text-objects-spec.coffee
+++ b/spec/text-objects-spec.coffee
@@ -46,78 +46,94 @@ describe "TextObjects", ->
 
       expect(editor.getSelectedScreenRange()).toEqual [[0, 6], [0, 11]]
 
-  describe "the 'i(' text object", ->
-    beforeEach ->
-      editor.setText("( something in here and in (here) )")
-      editor.setCursorScreenPosition([0, 9])
+  describe "inside parentheses", ->
+    insideParentheses = (keyAlias, keyOpts={}) ->
+      describe "the 'i#{keyAlias}' text object", ->
+        beforeEach ->
+          editor.setText("( something in here and in (here) )")
+          editor.setCursorScreenPosition([0, 9])
 
-    it "applies operators inside the current word in operator-pending mode", ->
-      keydown('d')
-      keydown('i')
-      keydown('(')
-      expect(editor.getText()).toBe "()"
-      expect(editor.getCursorScreenPosition()).toEqual [0, 1]
-      expect(editorView).not.toHaveClass('operator-pending-mode')
-      expect(editorView).toHaveClass('command-mode')
+        it "applies operators inside the current word in operator-pending mode", ->
+          keydown('d')
+          keydown('i')
+          keydown(keyAlias, keyOpts)
+          expect(editor.getText()).toBe "()"
+          expect(editor.getCursorScreenPosition()).toEqual [0, 1]
+          expect(editorView).not.toHaveClass('operator-pending-mode')
+          expect(editorView).toHaveClass('command-mode')
 
-    it "applies operators inside the current word in operator-pending mode (second test)", ->
-      editor.setCursorScreenPosition([0, 29])
-      keydown('d')
-      keydown('i')
-      keydown('(')
-      expect(editor.getText()).toBe "( something in here and in () )"
-      expect(editor.getCursorScreenPosition()).toEqual [0, 28]
-      expect(editorView).not.toHaveClass('operator-pending-mode')
-      expect(editorView).toHaveClass('command-mode')
+        it "applies operators inside the current word in operator-pending mode (second test)", ->
+          editor.setCursorScreenPosition([0, 29])
+          keydown('d')
+          keydown('i')
+          keydown(keyAlias, keyOpts)
+          expect(editor.getText()).toBe "( something in here and in () )"
+          expect(editor.getCursorScreenPosition()).toEqual [0, 28]
+          expect(editorView).not.toHaveClass('operator-pending-mode')
+          expect(editorView).toHaveClass('command-mode')
 
-  describe "the 'i{' text object", ->
-    beforeEach ->
-      editor.setText("{ something in here and in {here} }")
-      editor.setCursorScreenPosition([0, 9])
+    insideParentheses('(')
+    insideParentheses(')')
+    insideParentheses('b')
 
-    it "applies operators inside the current word in operator-pending mode", ->
-      keydown('d')
-      keydown('i')
-      keydown('{')
-      expect(editor.getText()).toBe "{}"
-      expect(editor.getCursorScreenPosition()).toEqual [0, 1]
-      expect(editorView).not.toHaveClass('operator-pending-mode')
-      expect(editorView).toHaveClass('command-mode')
+  describe "inside curly brackets", ->
+    insideCurlyBrackets = (keyAlias, keyOpts={}) ->
+      describe "the 'i#{keyAlias}' text object", ->
+        beforeEach ->
+          editor.setText("{ something in here and in {here} }")
+          editor.setCursorScreenPosition([0, 9])
 
-    it "applies operators inside the current word in operator-pending mode (second test)", ->
-      editor.setCursorScreenPosition([0, 29])
-      keydown('d')
-      keydown('i')
-      keydown('{')
-      expect(editor.getText()).toBe "{ something in here and in {} }"
-      expect(editor.getCursorScreenPosition()).toEqual [0, 28]
-      expect(editorView).not.toHaveClass('operator-pending-mode')
-      expect(editorView).toHaveClass('command-mode')
+        it "applies operators inside the current word in operator-pending mode", ->
+          keydown('d')
+          keydown('i')
+          keydown(keyAlias, keyOpts)
+          expect(editor.getText()).toBe "{}"
+          expect(editor.getCursorScreenPosition()).toEqual [0, 1]
+          expect(editorView).not.toHaveClass('operator-pending-mode')
+          expect(editorView).toHaveClass('command-mode')
 
+        it "applies operators inside the current word in operator-pending mode (second test)", ->
+          editor.setCursorScreenPosition([0, 29])
+          keydown('d')
+          keydown('i')
+          keydown(keyAlias, keyOpts)
+          expect(editor.getText()).toBe "{ something in here and in {} }"
+          expect(editor.getCursorScreenPosition()).toEqual [0, 28]
+          expect(editorView).not.toHaveClass('operator-pending-mode')
+          expect(editorView).toHaveClass('command-mode')
 
-  describe "the 'i<' text object", ->
-    beforeEach ->
-      editor.setText("< something in here and in <here> >")
-      editor.setCursorScreenPosition([0, 9])
+    insideCurlyBrackets('{')
+    insideCurlyBrackets('}')
+    insideCurlyBrackets('B', shift: true)
 
-    it "applies operators inside the current word in operator-pending mode", ->
-      keydown('d')
-      keydown('i')
-      keydown('<')
-      expect(editor.getText()).toBe "<>"
-      expect(editor.getCursorScreenPosition()).toEqual [0, 1]
-      expect(editorView).not.toHaveClass('operator-pending-mode')
-      expect(editorView).toHaveClass('command-mode')
+  describe "inside angle brackets", ->
+    insideAngleBrackets = (keyAlias, keyOpts={}) ->
+      describe "the 'i#{keyAlias}' text object", ->
+        beforeEach ->
+          editor.setText("< something in here and in <here> >")
+          editor.setCursorScreenPosition([0, 9])
 
-    it "applies operators inside the current word in operator-pending mode (second test)", ->
-      editor.setCursorScreenPosition([0, 29])
-      keydown('d')
-      keydown('i')
-      keydown('<')
-      expect(editor.getText()).toBe "< something in here and in <> >"
-      expect(editor.getCursorScreenPosition()).toEqual [0, 28]
-      expect(editorView).not.toHaveClass('operator-pending-mode')
-      expect(editorView).toHaveClass('command-mode')
+        it "applies operators inside the current word in operator-pending mode", ->
+          keydown('d')
+          keydown('i')
+          keydown(keyAlias, keyOpts)
+          expect(editor.getText()).toBe "<>"
+          expect(editor.getCursorScreenPosition()).toEqual [0, 1]
+          expect(editorView).not.toHaveClass('operator-pending-mode')
+          expect(editorView).toHaveClass('command-mode')
+
+        it "applies operators inside the current word in operator-pending mode (second test)", ->
+          editor.setCursorScreenPosition([0, 29])
+          keydown('d')
+          keydown('i')
+          keydown(keyAlias, keyOpts)
+          expect(editor.getText()).toBe "< something in here and in <> >"
+          expect(editor.getCursorScreenPosition()).toEqual [0, 28]
+          expect(editorView).not.toHaveClass('operator-pending-mode')
+          expect(editorView).toHaveClass('command-mode')
+
+    insideAngleBrackets('<')
+    insideAngleBrackets('>')
 
   describe "the 'i\'' text object", ->
     beforeEach ->


### PR DESCRIPTION
- `i}` and `iB` as aliases of `i{`
- `i)` and `ib` as aliases of `i(`
- `i>` as alias of `i<`

As described in http://vimhelp.appspot.com/motion.txt.html#i%29
