### PR TITLE
fix final cursor position after yank

### DIFF
--- a/lib/operators/general-operators.coffee
+++ b/lib/operators/general-operators.coffee
@@ -1,5 +1,5 @@
 _ = require 'underscore-plus'
-{$$, Range} = require 'atom'
+{$$, Point, Range} = require 'atom'
 {ViewModel} = require '../view-models/view-model'
 
 class OperatorError
@@ -142,20 +142,17 @@ class Yank extends Operator
   # Returns nothing.
   execute: (count=1) ->
     originalPosition = @editor.getCursorScreenPosition()
-
     if _.contains(@motion.select(count), true)
+      selectedPosition = @editor.getCursorScreenPosition()
       text = @editor.getSelection().getText()
+      originalPosition = Point.min(originalPosition, selectedPosition)
     else
       text = ''
     type = if @motion.isLinewise?() then 'linewise' else 'character'
 
     @vimState.setRegister(@register, {text, type})
 
-    if @motion.isLinewise?()
-      @editor.setCursorScreenPosition(originalPosition)
-    else
-      @editor.clearSelections()
-
+    @editor.setCursorScreenPosition(originalPosition)
     @vimState.activateCommandMode()
 
 #

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -436,6 +436,8 @@ describe "Operators", ->
 
       it "saves the line to the default register", ->
         expect(vimState.getRegister('"').text).toBe "012 345\n"
+
+      it "leaves the cursor at the starting position", ->
         expect(editor.getCursorScreenPosition()).toEqual [0, 4]
 
     describe "when followed with a repeated y", ->
@@ -446,6 +448,9 @@ describe "Operators", ->
 
       it "copies n lines, starting from the current", ->
         expect(vimState.getRegister('"').text).toBe "012 345\nabc\n"
+
+      it "leaves the cursor at the starting position", ->
+        expect(editor.getCursorScreenPosition()).toEqual [0, 4]
 
     describe "with a register", ->
       beforeEach ->
@@ -464,6 +469,31 @@ describe "Operators", ->
 
       it "saves the first word to the default register", ->
         expect(vimState.getRegister('"').text).toBe '345'
+
+      it "leaves the cursor at the starting position", ->
+        expect(editor.getCursorScreenPosition()).toEqual [0, 4]
+
+    describe "with a left motion", ->
+      beforeEach ->
+        keydown('y')
+        keydown('h')
+
+        it "saves the left letter to the default register", ->
+          expect(vimState.getRegister('"').text).toBe " "
+
+        it "moves the cursor position to the left", ->
+          expect(editor.getCursorScreenPosition()).toEqual [0, 3]
+
+    describe "with a down motion", ->
+      beforeEach ->
+        keydown 'y'
+        keydown 'j'
+
+      it "saves both full lines to the default register", ->
+        expect(vimState.getRegister('"').text).toBe "012 345\nabc\n"
+
+      it "leaves the cursor at the starting position", ->
+        expect(editor.getCursorScreenPosition()).toEqual [0, 4]
 
   describe "the yy keybinding", ->
     describe "on a single line file", ->


### PR DESCRIPTION
This seems to follow how VIM leaves the cursor after yanking.

| command | final cursor position |
| --- | --- |
| y2y | original position |
| yw | original position |
| ye | original position |
| yb | back 1 word |
| yh | back 1 column |
