### PR TITLE
Added fix for bug # 219

### DIFF
--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -18,6 +18,7 @@ class VimState
   opStack: null
   mode: null
   submode: null
+  InitialSelectedRange: null
 
   constructor: (@editorView) ->
     @editor = @editorView.editor
@@ -416,7 +417,9 @@ class VimState
     @changeModeClass('visual-mode')
 
     if @submode == 'linewise'
+
       @editor.selectLine()
+      @InitialSelectedRange = @editor.getSelection().getBufferRange()
 
     @updateStatusBar()
 


### PR DESCRIPTION
The vim state now has a initial selected range member. It is used when in visual mode to know when moving up or down to add or subtract to the start or end of the selected range. 
If visual mode is not active when moving up or down, the code executes the original call to editor.selectup/down 
