### PR TITLE
Fix repeating `>` with multiline selections

### DIFF
--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -14,10 +14,15 @@ class Motion
   inVisualMode: -> @vimState.mode == "visual"
 
 class CurrentSelection extends Motion
+  constructor: (@editor, @vimState) ->
+    super(@editor, @vimState)
+    @selection = @editor.getSelectedBufferRanges()
+
   execute: (count=1) ->
     _.times(count, -> true)
 
   select: (count=1) ->
+    @editor.setSelectedBufferRanges(@selection)
     _.times(count, -> true)
 
   isLinewise: -> @vimState.mode == 'visual' and @vimState.submode == 'linewise'

--- a/lib/operators/indent-operators.coffee
+++ b/lib/operators/indent-operators.coffee
@@ -19,9 +19,8 @@ class Indent extends Operator
   #
   # Returns nothing.
   indent: (count, direction='indent') ->
-    row = @editor.getCursorScreenRow()
-
     @motion.select(count)
+    {start} = @editor.getSelectedBufferRange()
     if direction == 'indent'
       @editor.indentSelectedRows()
     else if direction == 'outdent'
@@ -29,7 +28,7 @@ class Indent extends Operator
     else if direction == 'auto'
       @editor.autoIndentSelectedRows()
 
-    @editor.setCursorScreenPosition([row, 0])
+    @editor.setCursorBufferPosition([start.row, 0])
     @editor.moveCursorToFirstCharacterOfLine()
 
 #


### PR DESCRIPTION
Fixes #364

This changes CurrentSelection store the selection when it's created, so it can recreate that selection when a command using that selection is repeated.

Also changed the indent operator to put the cursor on the first line of the changed lines when done, instead of where the cursor was before the operation (which caused incorrect behavior when the text was selected starting from below) 
