### PR TITLE
Adds a coffeelint.json file to the project.

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,0 +1,103 @@
+{
+    "arrow_spacing": {
+        "level": "ignore"
+    },
+    "camel_case_classes": {
+        "level": "error"
+    },
+    "coffeescript_error": {
+        "level": "error"
+    },
+    "colon_assignment_spacing": {
+        "level": "ignore",
+        "spacing": {
+            "left": 0,
+            "right": 0
+        }
+    },
+    "cyclomatic_complexity": {
+        "value": 10,
+        "level": "ignore"
+    },
+    "duplicate_key": {
+        "level": "error"
+    },
+    "empty_constructor_needs_parens": {
+        "level": "ignore"
+    },
+    "indentation": {
+        "value": 2,
+        "level": "error"
+    },
+    "line_endings": {
+        "level": "ignore",
+        "value": "unix"
+    },
+    "max_line_length": {
+        "value": 80,
+        "level": "error",
+        "limitComments": true
+    },
+    "missing_fat_arrows": {
+        "level": "ignore"
+    },
+    "newlines_after_classes": {
+        "value": 3,
+        "level": "ignore"
+    },
+    "no_backticks": {
+        "level": "error"
+    },
+    "no_debugger": {
+        "level": "warn"
+    },
+    "no_empty_functions": {
+        "level": "ignore"
+    },
+    "no_empty_param_list": {
+        "level": "ignore"
+    },
+    "no_implicit_braces": {
+        "level": "ignore",
+        "strict": true
+    },
+    "no_implicit_parens": {
+        "strict": true,
+        "level": "ignore"
+    },
+    "no_interpolation_in_single_quotes": {
+        "level": "ignore"
+    },
+    "no_plusplus": {
+        "level": "ignore"
+    },
+    "no_stand_alone_at": {
+        "level": "ignore"
+    },
+    "no_tabs": {
+        "level": "error"
+    },
+    "no_throwing_strings": {
+        "level": "error"
+    },
+    "no_trailing_semicolons": {
+        "level": "error"
+    },
+    "no_trailing_whitespace": {
+        "level": "error",
+        "allowed_in_comments": false,
+        "allowed_in_empty_lines": true
+    },
+    "no_unnecessary_double_quotes": {
+        "level": "ignore"
+    },
+    "no_unnecessary_fat_arrows": {
+        "level": "warn"
+    },
+    "non_empty_constructor_needs_parens": {
+        "level": "ignore"
+    },
+    "space_operators": {
+        "level": "ignore"
+    }
+}


### PR DESCRIPTION
- Particularly this is useful to set linter to 2 spaces per tab.
- Some developers for example may use 4 space tabs and set that in their default
  coffeelint.json lint.
