### PR TITLE
Adds coffeelint.json to the .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+coffeelint.json


### PR DESCRIPTION
- Lets users override default coffeelint settings for vim-mode.
- For example can change their default from 4 to 2 spaces.
