### PR TITLE
Fix 'h' and 'l' with folding and soft wraps.

### DIFF
--- a/spec/fixtures/fold-text.md
+++ b/spec/fixtures/fold-text.md
@@ -1,0 +1,10 @@
+* Some
+    * Foldable stuff
+        * More foldable stuff
+* B1 B1x B1xx
+    * B2 B2x B2xx
+* C1 C1x
+* D1 D1x
+* E1
+* F1 F1x F1xx F1xxx
+	* F2 F2x F2xx F2xxx (begins with tab)

--- a/spec/motions-folds-spec.coffee
+++ b/spec/motions-folds-spec.coffee
@@ -1,0 +1,68 @@
+_ = require 'underscore-plus'
+helpers = require './spec-helper'
+path = require 'path'
+{WorkspaceView} = require 'atom'
+
+describe "Motions", ->
+  [editor, editorView, vimModePromise] = []
+
+  afterEach ->
+    waitsFor ->
+      atom.packages.deactivatePackage 'vim-mode'
+
+  beforeEach ->
+    atom.workspaceView = new WorkspaceView
+    atom.project.setPath(path.join(__dirname, 'fixtures'))
+
+    waitsForPromise ->
+      atom.workspace.open 'fold-text.md'
+
+    runs ->
+      atom.workspaceView.attachToDom()
+      editorView = atom.workspaceView.getActiveView()
+      editor = editorView.getEditor()
+      vimModePromise = atom.packages.activatePackage 'vim-mode'
+
+    waitsForPromise ->
+      vimModePromise
+
+  keydown = (key, options={}) ->
+    options.element ?= editorView[0]
+    helpers.keydown(key, options)
+
+  describe "motions under folded code", ->
+    initFold = ->
+      keydown 'j'
+      _.times 4, -> keydown 'l'
+      expect(editor.getCursorScreenPosition()).toEqual [1, 6]
+      editor.foldCurrentRow()
+      expect(editor.getCursorScreenPosition()).toEqual [1, 0]
+
+    beforeEach ->
+      initFold()
+
+    describe "the l keybinding", ->
+      describe "as a motion", ->
+        it "moves the cursor to next non folded line,
+          but stops at end of normal line", ->
+          _.times 50, -> keydown 'l'
+          # scrolls to next line and end of next line
+          expect(editor.getCursorScreenPosition()).toEqual [2, 12]
+
+        it "moves the cursor right, but not beyond end of line", ->
+          _.times 2, -> keydown 'j'
+          _.times 50, -> keydown 'l'
+          # scrolls to end of line "5" (4th on screen but 0 based so 3)
+          expect(editor.getCursorScreenPosition()).toEqual [3, 16]
+
+  describe "motions with tabs", ->
+    describe "the l keybinding", ->
+      describe "as a motion", ->
+        it "moves the cursor right, but not beyond end of line", ->
+          # NOTE: This test handles edge case for scrolling
+          # from beginning of line (through the tabs).
+          # No other test failed when this functionality broke.
+          _.times 9, -> keydown 'j'
+          _.times 50, -> keydown 'l'
+          # scrolls to end of line "10" (but 0 based so 9)
+          expect(editor.getCursorScreenPosition()).toEqual [9, 38]


### PR DESCRIPTION
This is a fix for left and right movement when in soft wraps or when code folding is present.

There are several issues I can hunt down related if we get closer to launching this.  I don't have any new tests for this, although all existing ones pass.  I wanted to start the discussion of how to create tests for this.  In my package jumpy for folding tests I open a file that has a .md extension and trigger a fold.  I didn't particularly test soft wraps, although I sort of got that for free.

I wasn't able to locate a similar file / similar approach.  Am I missing it or is everyone opposed to that idea?  It's more integration test as opposed to unit of course.

Also, as I was going to create this, I just noticed @Zren posted this https://github.com/atom/vim-mode/pull/354

There might be a chance mine fixes this, I haven't tested it yet.  Similar approaches of trying for a clip.

I handled some edge cases and made left work better as well for soft wraps.
