### PR TITLE
Use buffer position rather than screen position in h/l movement

### DIFF
--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -41,12 +41,12 @@ class MotionWithInput extends Motion
 class MoveLeft extends Motion
   execute: (count=1) ->
     _.times count, =>
-      {row, column} = @editor.getCursorScreenPosition()
+      {column} = @editor.getCursorBufferPosition()
       @editor.moveCursorLeft() if column > 0
 
   select: (count=1) ->
     _.times count, =>
-      {row, column} = @editor.getCursorScreenPosition()
+      {column} = @editor.getCursorBufferPosition()
 
       if column > 0
         @editor.selectLeft()
@@ -57,9 +57,8 @@ class MoveLeft extends Motion
 class MoveRight extends Motion
   execute: (count=1) ->
     _.times count, =>
-      {row, column} = @editor.getCursorScreenPosition()
-      lastCharIndex = @editor.getBuffer().lineForRow(row).length - 1
-      unless column >= lastCharIndex
+      {row, column} = @editor.getCursorBufferPosition()
+      if column < @editor.lineLengthForBufferRow(row) - 1
         @editor.moveCursorRight()
 
   select: (count=1) ->


### PR DESCRIPTION
In vim-mode, we don’t want h and l to move the cursor to a different
physical line. However, the code that was implementing this behavior
was using screen positions instead of buffer positions, resulting in
incorrect behavior in the presence of folds and soft wraps.

Now h and l can move across soft wraps, and folds above the current line
no longer cause incorrect behavior. This also fixes issues when hard
tabs were present on the line, again caused by using screen positions
instead of buffer positions.

Closes #399
Closes #354
