### PR TITLE
Don't clear " register 'o' or 'O' on empty line

### DIFF
--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -94,7 +94,7 @@ class VimState
   registerChangeHandler: (buffer) ->
     buffer.on 'changed', ({newRange, newText, oldRange, oldText}) =>
       return unless @setRegister?
-      if newText == ''
+      if newText == '' and oldText != ''
         @setRegister('"', text: oldText, type: Utils.copyType(oldText))
 
   # Private: Creates the plugin's bindings

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -708,6 +708,17 @@ describe "Operators", ->
       keydown 'u'
       expect(editor.getText()).toBe "  abc\n  012\n"
 
+    it 'does not clear the " register', ->
+      editor.getBuffer().setText("abc\n\n012\n\ndef")
+      editor.setCursorScreenPosition([2, 0])
+      keydown('y')
+      keydown('y')
+      expect(vimState.getRegister('"').text).toBe "012\n"
+      keydown('k')
+      keydown('O')
+      keydown 'escape'
+      expect(vimState.getRegister('"').text).toBe "012\n"
+
   describe "the o keybinding", ->
     beforeEach ->
       spyOn(editor, 'shouldAutoIndent').andReturn(true)
@@ -747,6 +758,16 @@ describe "Operators", ->
       keydown 'u'
       expect(editor.getText()).toBe "abc\n  012\n"
 
+    it 'does not clear the " register', ->
+      editor.getBuffer().setText("abc\n\n012\n\ndef")
+      editor.setCursorScreenPosition([2, 0])
+      keydown('y')
+      keydown('y')
+      expect(vimState.getRegister('"').text).toBe "012\n"
+      keydown('j')
+      keydown('o')
+      keydown 'escape'
+      expect(vimState.getRegister('"').text).toBe "012\n"
 
   describe "the a keybinding", ->
     beforeEach ->


### PR DESCRIPTION
I opened a PR for this earlier but I didn't properly understand what was going on, so I closed it. Now I'm clear on what the issue is and exactly how to reproduce. It makes sense, for example, that it especially bothered me, because I mostly used Atom to edit Markdown documents.

An 'o' or 'O' that placed the cursor at the start of a line would cause the
registerChangeHandler method in VimState to receive a change of newText '',
oldText ''. The old text of '' would be put in the " register, wiping out
anything that had been yanked previously.

In other words, if you opened up a line and the new cursor position was
indented, then the " register was preserved. But if you moved to the start of
an empty line and opened up the next line such that the cursor was now on the
first position of the line, then the " register would be wiped out. This is
more noticeable when editing an unindented document than when editing code.

In any case, there doesn't seem to be a legitimate case for storing a change
that doesn't change the buffer.
