### PR TITLE
Fixed bug that did not allow for Ctrl C to be used to go into command mode

### DIFF
--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -1,8 +1,6 @@
 '.editor.vim-mode:not(.command-mode)':
   'escape': 'vim-mode:activate-command-mode'
   'ctrl-[': 'vim-mode:activate-command-mode'
-
-'.platform-darwin .editor.vim-mode:not(.command-mode)':
   'ctrl-c': 'vim-mode:activate-command-mode'
 
 '.editor.vim-mode:not(.insert-mode)':


### PR DESCRIPTION
I was using this when I noticed that I was not able to go into command mode using Ctrl-C. 

I decided to look at the source and discovered that when I remove those two lines, I could get into command mode.
