### PR TITLE
Support correct quote text object behavior

### DIFF
--- a/lib/text-objects.coffee
+++ b/lib/text-objects.coffee
@@ -32,16 +32,17 @@ class SelectInsideQuotes extends TextObject
     @lookForwardOnLine(start)
 
   isStartQuote: (end) ->
-    range = new Range([0,0],end)
-    numQuotes = range.toString().replace('\''+@char,'').split(@char).length-1
+    line = @editor.lineForBufferRow(end.row)
+    numQuotes = line.substring(0,end.column + 1).replace('\''+@char,'').split(@char).length-1
     return numQuotes % 2
 
 
   lookForwardOnLine: (pos) ->
     line = @editor.lineForBufferRow(pos.row)
-    idx = line.indexOf @char
+
+    idx = line.substring(pos.column).indexOf @char
     if idx >= 0
-      pos.column = idx
+      pos.column += idx
       return pos
     null
 

--- a/spec/text-objects-spec.coffee
+++ b/spec/text-objects-spec.coffee
@@ -13,7 +13,7 @@ describe "TextObjects", ->
 
       vimState = editorView.vimState
       vimState.activateCommandMode()
-      vimState.resetCommandMode()jj
+      vimState.resetCommandMode()
 
   keydown = (key, options={}) ->
     options.element ?= editorView[0]


### PR DESCRIPTION
This is a first stab at fixing the issues I raised in #379.  Commands like
`ci'` and `ca"` now behave as expected when outside of a string.  

I've updated the tests to check for the right behavior and wrote an initial implementation.
Unfortunately my first take is pretty hopelessly naive.
I'm iterating all the way back through the file to count quote marks to tell if I'm inside 
a quote or between 2 strings.  I'd love feedback from somebody with a better
knowledge of Atom internals/APIs about what I can do better to avoid running up the whole file,
there's a noticeable lag when using these text objects at the end of large files right now.

Clumping up the whole earlier text into a string, removing escaped quotes and filtering other characters 
would probably be more efficient but still slow.  I'd love any feedback from Atom experts on how to make this better.
