### PR TITLE
Don't create VimState if one already exists

### DIFF
--- a/lib/vim-mode.coffee
+++ b/lib/vim-mode.coffee
@@ -17,7 +17,7 @@ module.exports =
       return if editorView.mini
 
       editorView.addClass('vim-mode')
-      editorView.vimState = new VimState(editorView)
+      editorView.vimState ?= new VimState(editorView)
 
   deactivate: ->
     atom.workspaceView?.eachEditorView (editorView) =>


### PR DESCRIPTION
Fixes vidius/atom-pain-split#5, among others. Did you know that `eachEditorView` revisits a view when you move it to another pane? Because I had no idea. Very subtle.