### PR TITLE
optimize find motion visual effect

### DIFF
--- a/lib/motions/search-motion.coffee
+++ b/lib/motions/search-motion.coffee
@@ -24,9 +24,16 @@ class SearchBase extends MotionWithInput
     @
 
   execute: (count=1) ->
+    flashDuration = 500
     @scan()
     @match count, (pos) =>
       @editor.setCursorBufferPosition(pos.range.start)
+      marker = @editor.markBufferRange(pos.range)
+      flashDecoration = @editor.decorateMarker(marker, type: 'highlight', class: 'selection')
+      flashDecoration.flash('flash', flashDuration)
+      setTimeout( ->
+        marker.destroy()
+      , flashDuration*2/3)
 
   select: (count=1) ->
     @scan()


### PR DESCRIPTION
I optimize the visual effect of search motion using Atom's decoration flash effect.
https://github.com/atom/atom/blob/v0.141.0/src/decoration.coffee#L162

Since https://github.com/atom/atom/blob/v0.141.0/src/highlight-component.coffee#L42 doesn't provide a callback after completion, I use setTimeout() to destroy the marker.

Following is the screenshot
![vimsearch](https://cloud.githubusercontent.com/assets/3467445/4873630/61a7030c-621d-11e4-9621-ebcfadd10d4a.gif)
