### PR TITLE
Fix scroll cursor docs

### DIFF
--- a/docs/scrolling.md
+++ b/docs/scrolling.md
@@ -4,7 +4,7 @@
 * [ctrl-y](http://vimhelp.appspot.com/scroll.txt.html#CTRL-Y)
 * [ctrl-f](http://vimhelp.appspot.com/scroll.txt.html#CTRL-F)
 * [ctrl-b](http://vimhelp.appspot.com/scroll.txt.html#CTRL-B)
-* [z<CR>](http://vimhelp.appspot.com/scroll.txt.html#z%3CCR%3E)
+* [z enter](http://vimhelp.appspot.com/scroll.txt.html#z%3CCR%3E)
 * [zt](http://vimhelp.appspot.com/scroll.txt.html#zt)
 * [z.](http://vimhelp.appspot.com/scroll.txt.html#z.)
 * [zz](http://vimhelp.appspot.com/scroll.txt.html#zz)


### PR DESCRIPTION
Markdown didn't like `<CR>` in the link text.
