### PR TITLE
keymaps/vim-mode: add support for :w and :q

### DIFF
--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -17,6 +17,9 @@
   'j': 'vim-mode:move-down'
   'down': 'vim-mode:move-down'
 
+  ': w enter': 'core:save'
+  ': q enter': 'core:close'
+
   'w': 'vim-mode:move-to-next-word'
   'W': 'vim-mode:move-to-next-whole-word'
   'e': 'vim-mode:move-to-end-of-word'


### PR DESCRIPTION
I wish this were easier to write so that `:wq` could be composed simpler, but I am not aware of a way to do this.

Closes #439
