### PR TITLE
Use checkpoints instead of open-ended transactions

### DIFF
--- a/lib/operators/input.coffee
+++ b/lib/operators/input.coffee
@@ -32,7 +32,7 @@ class InsertAfter extends Insert
 
 class InsertAboveWithNewline extends Insert
   execute: (count=1) ->
-    @editor.beginTransaction() unless @typingCompleted
+    @vimState.setInsertionCheckpoint() unless @typingCompleted
     @editor.insertNewlineAbove()
     @editor.getLastCursor().skipLeadingWhitespace()
 
@@ -47,7 +47,7 @@ class InsertAboveWithNewline extends Insert
 
 class InsertBelowWithNewline extends Insert
   execute: (count=1) ->
-    @editor.beginTransaction() unless @typingCompleted
+    @vimState.setInsertionCheckpoint() unless @typingCompleted
     @editor.insertNewlineBelow()
     @editor.getLastCursor().skipLeadingWhitespace()
 
@@ -74,7 +74,7 @@ class Change extends Insert
   execute: (count) ->
     # If we've typed, we're being repeated. If we're being repeated,
     # undo transactions are already handled.
-    @editor.beginTransaction() unless @typingCompleted
+    @vimState.setInsertionCheckpoint() unless @typingCompleted
     operator = new Delete(@editor, @vimState, allowEOL: true, selectOptions: {excludeWhitespace: true})
     operator.compose(@motion)
 
@@ -103,7 +103,7 @@ class Change extends Insert
 class Substitute extends Insert
   register: '"'
   execute: (count=1) ->
-    @editor.beginTransaction() unless @typingCompleted
+    @vimState.setInsertionCheckpoint() unless @typingCompleted
     _.times count, =>
       @editor.selectRight()
     text = @editor.getLastSelection().getText()
@@ -120,7 +120,7 @@ class Substitute extends Insert
 class SubstituteLine extends Insert
   register: '"'
   execute: (count=1) ->
-    @editor.beginTransaction() unless @typingCompleted
+    @vimState.setInsertionCheckpoint() unless @typingCompleted
     @editor.moveToBeginningOfLine()
     _.times count, =>
       @editor.selectDown()

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -361,18 +361,22 @@ class VimState
   # Private: Used to enable insert mode.
   #
   # Returns nothing.
-  activateInsertMode: (transactionStarted = false)->
+  activateInsertMode: ->
     @mode = 'insert'
     @editorElement.component.setInputEnabled(true)
-    @editor.beginTransaction() unless transactionStarted
+    @setInsertionCheckpoint()
     @submode = null
     @changeModeClass('insert-mode')
     @updateStatusBar()
 
+  setInsertionCheckpoint: ->
+    @insertionCheckpoint = @editor.createCheckpoint() unless @insertionCheckpoint?
+
   deactivateInsertMode: ->
     @editorElement.component.setInputEnabled(false)
     return unless @mode == 'insert'
-    @editor.commitTransaction()
+    @editor.groupChangesSinceCheckpoint(@insertionCheckpoint)
+    @insertionCheckpoint = null
     transaction = _.last(@editor.buffer.history.undoStack)
     item = @inputOperator(@history[0])
     if item? and transaction?


### PR DESCRIPTION
This can't be merged until atom/atom@bf83fb7 is released in v0.151.

Closes #446.

This makes vim-mode compatible with autocomplete. Refs atom/autocomplete#53.
