### PR TITLE
vim-mode extensibility 

### DIFF
--- a/lib/vim-mode.coffee
+++ b/lib/vim-mode.coffee
@@ -35,12 +35,11 @@ module.exports =
       @editorStateMap[editor.id] = vimState
       @emitter.emit 'did-attach', vimState
 
-      stateDisposable = new Disposable =>
-        delete @editorStateMap[vimState.editor.id]
+      stateDisposable = new Disposable ->
         vimState.destroy()
 
       @disposables.add stateDisposable
-      editor.onDidDestroy -> stateDisposable.dispose()
+      editor.onDidDestroy => delete @editorStateMap[vimState.editor.id]
 
     version = require('../package.json').version
     @disposables.add atom.services.provide "vim-mode", version,

--- a/lib/vim-mode.coffee
+++ b/lib/vim-mode.coffee
@@ -58,9 +58,3 @@ module.exports =
     for id, vimState of @editorStateMap
         callback(vimState)
     @onDidAttach(callback)
-
-module.exports.Motions = require './motions'
-module.exports.Operators = require './operators'
-module.exports.ViewModels = require './view-models/view-model'
-module.exports.ViewModels.VimCommandModeInputView =
-  require './view-models/vim-command-mode-input-view'

--- a/lib/vim-mode.coffee
+++ b/lib/vim-mode.coffee
@@ -1,4 +1,4 @@
-{Disposable, CompositeDisposable} = require 'event-kit'
+{Disposable, CompositeDisposable, Emitter} = require 'event-kit'
 StatusBarManager = require './status-bar-manager'
 GlobalVimState = require './global-vim-state'
 VimState = require './vim-state'
@@ -12,8 +12,11 @@ module.exports =
       type: 'boolean'
       default: false
 
+  emitter: new Emitter
+
   activate: (state) ->
     @disposables = new CompositeDisposable
+    @editorStateMap = {}
     globalVimState = new GlobalVimState
     statusBarManager = new StatusBarManager
 
@@ -29,8 +32,36 @@ module.exports =
         globalVimState
       )
 
-      @disposables.add new Disposable =>
+      @editorStateMap[editor.id] = vimState
+      @emitter.emit 'did-attach', vimState
+
+      stateDisposable = new Disposable =>
+        delete @editorStateMap[vimState.editor.id]
         vimState.destroy()
+
+      @disposables.add stateDisposable
+      editor.onDidDestroy -> stateDisposable.dispose()
+
+    version = require('../package.json').version
+    @disposables.add atom.services.provide "vim-mode", version,
+      getStateForEditor: @getStateForEditor.bind(this)
+      onDidAttach: @onDidAttach.bind(this)
+      observeVimStates: @observeVimStates.bind(this)
 
   deactivate: ->
     @disposables.dispose()
+
+  getStateForEditor: (editor) -> @editorStateMap[editor.id]
+
+  onDidAttach: (callback) -> @emitter.on 'did-attach', callback
+
+  observeVimStates: (callback) ->
+    for id, vimState of @editorStateMap
+        callback(vimState)
+    @onDidAttach(callback)
+
+module.exports.Motions = require './motions'
+module.exports.Operators = require './operators'
+module.exports.ViewModels = require './view-models/view-model'
+module.exports.ViewModels.VimCommandModeInputView =
+  require './view-models/vim-command-mode-input-view'


### PR DESCRIPTION
Add interface for external vim-mode extension packages.

Extension packages are intended to augment vim-mode operator suite for some specific areas not appropriate to be included into main vim-mode distribution. Examples of such areas are:

* port of existing Vim plugin (e.g. `vim-surround` #188)
* language-specific motions (e.g. https://github.com/guns/vim-sexp)
* late-binding vim-mode functionality for existing packages (e.g. git integration)

The proposed workflow for extensions is:

* in `.activate` subscribe to `VimMode.observeVimStates`. In callback register new commands (operators/motions) which can use operation stack by means of `pushOperations` method of provided `VimState`
* at `vim-mode@did-deactivate` unregister provided commands and probably self-deactivate

This workflow will be changed when (if) Atom package dependence mechanism is introduced.

`vim-mode::getStateForEditor` is a convenience method which can be useful for just-installed packages.
