### PR TITLE
[RFC] Defer vim-state.coffee loading

### DIFF
--- a/lib/vim-mode.coffee
+++ b/lib/vim-mode.coffee
@@ -1,7 +1,7 @@
 {Disposable, CompositeDisposable} = require 'event-kit'
 StatusBarManager = require './status-bar-manager'
 GlobalVimState = require './global-vim-state'
-VimState = require './vim-state'
+VimState = null
 
 module.exports =
   config:
@@ -20,6 +20,7 @@ module.exports =
     @disposables.add statusBarManager.initialize()
     @disposables.add atom.workspace.observeTextEditors (editor) =>
       return if editor.mini
+      VimState ?= require './vim-state'
 
       element = atom.views.getView(editor)
 


### PR DESCRIPTION
I was wondering is it acceptable to defer vim-state.coffee loading until the first text editor is created?

On my machine with this change vim-mode loading time goes from ~100ms down to ~15ms.
On the other hand, this change will slow down first text editor opening a bit.

Change was proposed by @lee-dohm in atom/atom#2654. 