### PR TITLE
Fix scrolling up/down so it moves by 1 line.

### DIFF
--- a/lib/scroll.coffee
+++ b/lib/scroll.coffee
@@ -5,7 +5,7 @@ class Scroll
     @scrolloff = 2 # atom default
     @rows =
       first: @editor.getFirstVisibleScreenRow()
-      last: @editor.getLastVisibleScreenRow()
+      last: @editor.getLastVisibleScreenRow() - 1
       final: @editor.getLastScreenRow()
 
 class ScrollDown extends Scroll
@@ -15,8 +15,8 @@ class ScrollDown extends Scroll
 
   keepCursorOnScreen: (count) ->
     {row, column} = @editor.getCursorScreenPosition()
-    firstScreenRow = @rows.first + @scrolloff + 1
-    if row - count <= firstScreenRow
+    firstScreenRow = @rows.first + @scrolloff
+    if row - count < firstScreenRow
       @editor.setCursorScreenPosition([firstScreenRow + count, column])
 
   scrollUp: (count) ->
@@ -30,8 +30,8 @@ class ScrollUp extends Scroll
 
   keepCursorOnScreen: (count) ->
     {row, column} = @editor.getCursorScreenPosition()
-    lastScreenRow = @rows.last - @scrolloff - 1
-    if row + count >= lastScreenRow
+    lastScreenRow = @rows.last - @scrolloff
+    if row + count > lastScreenRow
         @editor.setCursorScreenPosition([lastScreenRow - count, column])
 
   scrollDown: (count) ->

--- a/spec/scroll-spec.coffee
+++ b/spec/scroll-spec.coffee
@@ -26,18 +26,42 @@ describe "Scrolling", ->
       spyOn(editor, 'scrollToScreenPosition')
 
     describe "the ctrl-e keybinding", ->
+      ###
+      0
+      1
+      2 <-
+      3
+      4 |
+      5
+      6
+      7 <-
+      8
+      9
+      ###
       beforeEach ->
         spyOn(editor, 'getCursorScreenPosition').andReturn({row: 4, column: 0})
         spyOn(editor, 'setCursorScreenPosition')
 
       it "moves the screen down by one and keeps cursor onscreen", ->
         keydown('e', ctrl: true)
-        expect(editor.scrollToScreenPosition).toHaveBeenCalledWith([7, 0])
-        expect(editor.setCursorScreenPosition).toHaveBeenCalledWith([6, 0])
+        expect(editor.scrollToScreenPosition).toHaveBeenCalledWith([6, 0])
+        expect(editor.setCursorScreenPosition).toHaveBeenCalledWith([5, 0])
 
     describe "the ctrl-y keybinding", ->
+      ###
+      0
+      1
+      2 <-
+      3
+      4
+      5 |
+      6
+      7 <-
+      8
+      9
+      ###
       beforeEach ->
-        spyOn(editor, 'getCursorScreenPosition').andReturn({row: 6, column: 0})
+        spyOn(editor, 'getCursorScreenPosition').andReturn({row: 5, column: 0})
         spyOn(editor, 'setCursorScreenPosition')
 
       it "moves the screen up by one and keeps the cursor onscreen", ->


### PR DESCRIPTION
Fix #430 once https://github.com/atom/atom/pull/4597 is merged.

Unfortunately, atom is not showing the integer number of lines all the time
so sometimes it looks like it's not scrolling correctly. This is because
scrolling up (ctrl-y) is done by requesting atom to show the top lines and
so very bottom line may be only partially shown (and so it sometimes feels
like it does not work correctly).