### PR TITLE
:bug: #465: cannot exit visual mode by hitting 'v'

### DIFF
--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -222,3 +222,5 @@
 '.editor.vim-mode.visual-mode':
   'x': 'vim-mode:delete'
   's': 'vim-mode:change'
+  'v': 'vim-mode:reset-command-mode'
+  'V': 'vim-mode:reset-command-mode'


### PR DESCRIPTION
This patch simply maps the 'v' and 'V' keys to reset command mode.
The cursor is kept on the end of the selection, as expected in vim.