### PR TITLE
Use status-bar through new service API

### DIFF
--- a/lib/status-bar-manager.coffee
+++ b/lib/status-bar-manager.coffee
@@ -12,11 +12,7 @@ class StatusBarManager
     @element.id = "status-bar-vim-mode"
     @element.classList.add("inline-block")
 
-  initialize: ->
-    @disposables = new CompositeDisposable
-    unless @attach()
-      @disposables.add atom.packages.onDidActivateInitialPackages => @attach()
-    @disposables
+  initialize: (@statusBar) ->
 
   update: (currentMode) ->
     for mode, [klass, html] of ContentsByMode
@@ -29,10 +25,7 @@ class StatusBarManager
   # Private
 
   attach: ->
-    statusBar = document.querySelector("status-bar")
-    if statusBar?
-      tile = statusBar.addRightTile(item: @element, priority: 20)
-      @disposables.add new Disposable => tile.destroy()
-      true
-    else
-      false
+    @tile = @statusBar.addRightTile(item: @element, priority: 20)
+
+  detach: ->
+    @tile.destroy()

--- a/lib/vim-mode.coffee
+++ b/lib/vim-mode.coffee
@@ -15,10 +15,9 @@ module.exports =
   activate: (state) ->
     @disposables = new CompositeDisposable
     globalVimState = new GlobalVimState
-    statusBarManager = new StatusBarManager
+    @statusBarManager = new StatusBarManager
     vimStates = new WeakMap
 
-    @disposables.add statusBarManager.initialize()
     @disposables.add atom.workspace.observeTextEditors (editor) =>
       return if editor.mini
 
@@ -27,7 +26,7 @@ module.exports =
       if not vimStates.get(editor)
         vimState = new VimState(
           element,
-          statusBarManager,
+          @statusBarManager,
           globalVimState
         )
 
@@ -38,3 +37,9 @@ module.exports =
 
   deactivate: ->
     @disposables.dispose()
+
+  consumeStatusBar: (statusBar) ->
+    @statusBarManager.initialize(statusBar)
+    @statusBarManager.attach()
+    @disposables.add new Disposable =>
+      @statusBarManager.detach()

--- a/package.json
+++ b/package.json
@@ -12,5 +12,12 @@
   "dependencies": {
     "underscore-plus": "1.x",
     "event-kit": "^0.7.2"
+  },
+  "consumedServices": {
+    "status-bar": {
+      "versions": {
+        "^0.58.0": "consumeStatusBar"
+      }
+    }
   }
 }

--- a/spec/vim-mode-spec.coffee
+++ b/spec/vim-mode-spec.coffee
@@ -1,16 +1,20 @@
 {Workspace} = require 'atom'
 
 describe "VimMode", ->
-  [editor, editorElement] = []
+  [editor, editorElement, workspaceElement] = []
 
   beforeEach ->
     atom.workspace = new Workspace
+    workspaceElement = atom.views.getView(atom.workspace)
 
     waitsForPromise ->
       atom.workspace.open()
 
     waitsForPromise ->
       atom.packages.activatePackage('vim-mode')
+
+    waitsForPromise ->
+      atom.packages.activatePackage('status-bar')
 
     runs ->
       editor = atom.workspace.getActiveTextEditor()
@@ -20,6 +24,12 @@ describe "VimMode", ->
     it "puts the editor in command-mode initially by default", ->
       expect(editorElement.classList.contains('vim-mode')).toBe(true)
       expect(editorElement.classList.contains('command-mode')).toBe(true)
+
+    it "shows the current vim mode in the status bar", ->
+      statusBarTile = workspaceElement.querySelector("#status-bar-vim-mode")
+      expect(statusBarTile.textContent).toBe("Command")
+      atom.commands.dispatch(editorElement, "vim-mode:activate-insert-mode")
+      expect(statusBarTile.textContent).toBe("Insert")
 
     it "doesn't register duplicate command listeners for editors", ->
       editor.setText("12345")


### PR DESCRIPTION
:warning: Depends on https://github.com/atom/status-bar/pull/51 being merged and released in Atom v0.178 :warning:

Signed-off-by: Max Brunsfeld <maxbrunsfeld@gmail.com>