### PR TITLE
:bug: fix tab handling in shift-B

### DIFF
--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -3,6 +3,7 @@ _ = require 'underscore-plus'
 
 WholeWordRegex = /\S+/
 WholeWordOrEmptyLineRegex = /^\s*$|\S+/
+AllWhitespace = /^\s$/
 
 class MotionError
   constructor: (@message) ->
@@ -188,7 +189,7 @@ class MoveToPreviousWholeWord extends Motion
 
   isWholeWord: (cursor) ->
     char = cursor.getCurrentWordPrefix().slice(-1)
-    char is ' ' or char is '\n'
+    AllWhitespace.test(char)
 
   isBeginningOfFile: (cursor) ->
     cur = cursor.getBufferPosition()

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -422,7 +422,7 @@ describe "Motions", ->
           expect(editor.getCursorScreenPosition()).toEqual [0, 1]
 
   describe "the B keybinding", ->
-    beforeEach -> editor.setText("cde1+- ab \n xyz-123\n\n zip")
+    beforeEach -> editor.setText("cde1+- ab \n\t xyz-123\n\n zip")
 
     describe "as a motion", ->
       beforeEach -> editor.setCursorScreenPosition([4, 1])
@@ -435,7 +435,7 @@ describe "Motions", ->
         expect(editor.getCursorScreenPosition()).toEqual [2, 0]
 
         keydown('B', shift:true)
-        expect(editor.getCursorScreenPosition()).toEqual [1, 1]
+        expect(editor.getCursorScreenPosition()).toEqual [1, 3]
 
         keydown('B', shift:true)
         expect(editor.getCursorScreenPosition()).toEqual [0, 7]
@@ -445,7 +445,7 @@ describe "Motions", ->
 
     describe "as a selection", ->
       it "selects to the beginning of the whole word", ->
-        editor.setCursorScreenPosition([1, 8])
+        editor.setCursorScreenPosition([1, 10])
         keydown('y')
         keydown('B', shift:true)
         expect(vimState.getRegister('"').text).toBe 'xyz-123'


### PR DESCRIPTION
shift-B would currently only look for spaces and newlines; it needs to handle any whitespace in skipping to the previous word

AllWhitespace modeled after lib/text-objects.coffee

This is my first little contribution to Atom, feel free to let me know if I'm doing something wrong.