### PR TITLE
Adds useClipboardAsDefaultRegister option.

### DIFF
--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -1,5 +1,6 @@
 _ = require 'underscore-plus'
 {Point, Range} = require 'atom'
+settings = require '../settings'
 
 WholeWordRegex = /\S+/
 WholeWordOrEmptyLineRegex = /^\s*$|\S+/
@@ -142,7 +143,7 @@ class MoveLeft extends Motion
 
   moveCursor: (cursor, count=1) ->
     _.times count, =>
-      cursor.moveLeft() if not cursor.isAtBeginningOfLine() or atom.config.get('vim-mode.wrapLeftRightMotion')
+      cursor.moveLeft() if not cursor.isAtBeginningOfLine() or settings.wrapLeftRightMotion()
       @ensureCursorIsWithinLine(cursor)
 
 class MoveRight extends Motion
@@ -151,7 +152,7 @@ class MoveRight extends Motion
   moveCursor: (cursor, count=1) ->
     _.times count, =>
       cursor.moveRight() unless cursor.isAtEndOfLine()
-      cursor.moveRight() if atom.config.get('vim-mode.wrapLeftRightMotion') and cursor.isAtEndOfLine()
+      cursor.moveRight() if settings.wrapLeftRightMotion() and cursor.isAtEndOfLine()
       @ensureCursorIsWithinLine(cursor)
 
 class MoveUp extends Motion

--- a/lib/motions/search-motion.coffee
+++ b/lib/motions/search-motion.coffee
@@ -3,6 +3,7 @@ _ = require 'underscore-plus'
 SearchViewModel = require '../view-models/search-view-model'
 {Input} = require '../view-models/view-model'
 {Point, Range} = require 'atom'
+settings = require '../settings'
 
 class SearchBase extends MotionWithInput
   operatesInclusively: false
@@ -56,7 +57,7 @@ class SearchBase extends MotionWithInput
   getSearchTerm: (term) ->
     modifiers = {'g': true}
 
-    if not term.match('[A-Z]') and atom.config.get('vim-mode.useSmartcaseForSearch')
+    if not term.match('[A-Z]') and settings.useSmartcaseForSearch()
       modifiers['i'] = true
 
     if term.indexOf('\\c') >= 0

--- a/lib/operators/general-operators.coffee
+++ b/lib/operators/general-operators.coffee
@@ -2,6 +2,7 @@ _ = require 'underscore-plus'
 {Point, Range} = require 'atom'
 {ViewModel} = require '../view-models/view-model'
 Utils = require '../utils'
+settings = require '../settings'
 
 class OperatorError
   constructor: (@message) ->
@@ -74,7 +75,7 @@ class OperatorWithInput extends Operator
 # It deletes everything selected by the following motion.
 #
 class Delete extends Operator
-  register: '"'
+  register: null
   allowEOL: null
 
   # allowEOL - Determines whether the cursor should be allowed to rest on the
@@ -83,6 +84,7 @@ class Delete extends Operator
     @complete = false
     @selectOptions ?= {}
     @selectOptions.requireEOL ?= true
+    @register = settings.defaultRegister()
 
   # Public: Deletes the text selected by the given motion.
   #
@@ -144,7 +146,11 @@ class ToggleCase extends Operator
 # It copies everything selected by the following motion.
 #
 class Yank extends Operator
-  register: '"'
+  register: null
+
+  constructor: (@editor, @vimState, {@allowEOL, @selectOptions}={}) ->
+    @register = settings.defaultRegister()
+
   # Public: Copies the text selected by the given motion.
   #
   # count - The number of times to execute.

--- a/lib/operators/input.coffee
+++ b/lib/operators/input.coffee
@@ -71,7 +71,7 @@ class InsertBelowWithNewline extends Insert
 class Change extends Insert
   standalone: false
   register: null
-  constructor: ->
+  constructor: (@editor, @vimState, {@selectOptions}={}) ->
       @register = settings.defaultRegister()
 
   # Public: Changes the text selected by the given motion.
@@ -99,7 +99,7 @@ class Change extends Insert
 
 class Substitute extends Insert
   register: null
-  constructor: ->
+  constructor: (@editor, @vimState, {@selectOptions}={}) ->
       @register = settings.defaultRegister()
   execute: (count=1) ->
     @vimState.setInsertionCheckpoint() unless @typingCompleted
@@ -118,7 +118,7 @@ class Substitute extends Insert
 
 class SubstituteLine extends Insert
   register: null
-  constructor: ->
+  constructor: (@editor, @vimState, {@selectOptions}={}) ->
       @register = settings.defaultRegister()
   execute: (count=1) ->
     @vimState.setInsertionCheckpoint() unless @typingCompleted

--- a/lib/operators/input.coffee
+++ b/lib/operators/input.coffee
@@ -1,5 +1,6 @@
 {Operator, Delete} = require './general-operators'
 _ = require 'underscore-plus'
+settings = require '../settings'
 
 # The operation for text entered in input mode. Broadly speaking, input
 # operators manage an undo transaction and set a @typingCompleted variable when
@@ -69,7 +70,9 @@ class InsertBelowWithNewline extends Insert
 #
 class Change extends Insert
   standalone: false
-  register: '"'
+  register: null
+  constructor: ->
+      @register = settings.defaultRegister()
 
   # Public: Changes the text selected by the given motion.
   #
@@ -95,7 +98,9 @@ class Change extends Insert
     @typingCompleted = true
 
 class Substitute extends Insert
-  register: '"'
+  register: null
+  constructor: ->
+      @register = settings.defaultRegister()
   execute: (count=1) ->
     @vimState.setInsertionCheckpoint() unless @typingCompleted
     _.times count, =>
@@ -112,7 +117,9 @@ class Substitute extends Insert
     @typingCompleted = true
 
 class SubstituteLine extends Insert
-  register: '"'
+  register: null
+  constructor: ->
+      @register = settings.defaultRegister()
   execute: (count=1) ->
     @vimState.setInsertionCheckpoint() unless @typingCompleted
     @editor.moveToBeginningOfLine()

--- a/lib/operators/put-operator.coffee
+++ b/lib/operators/put-operator.coffee
@@ -1,16 +1,18 @@
 _ = require 'underscore-plus'
 {Operator} = require './general-operators'
+settings = require '../settings'
 
 module.exports =
 #
 # It pastes everything contained within the specifed register
 #
 class Put extends Operator
-  register: '"'
+  register: null
 
   constructor: (@editor, @vimState, {@location, @selectOptions}={}) ->
     @location ?= 'after'
     @complete = true
+    @register = settings.defaultRegister()
 
   # Public: Pastes the text in the given register.
   #

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -1,0 +1,24 @@
+
+settings =
+  config:
+    startInInsertMode:
+      type: 'boolean'
+      default: false
+    useSmartcaseForSearch:
+      type: 'boolean'
+      default: false
+    wrapLeftRightMotion:
+      type: 'boolean'
+      default: false
+    useClipboardAsDefaultRegister:
+      type: 'boolean'
+      default: false
+
+Object.keys(settings.config).forEach (k) ->
+  settings[k] = ->
+    atom.config.get('vim-mode.'+k)
+
+settings.defaultRegister = ->
+  if settings.useClipboardAsDefaultRegister() then '*' else '"'
+
+module.exports = settings

--- a/lib/vim-mode.coffee
+++ b/lib/vim-mode.coffee
@@ -2,18 +2,10 @@
 StatusBarManager = require './status-bar-manager'
 GlobalVimState = require './global-vim-state'
 VimState = require './vim-state'
+settings = require './settings'
 
 module.exports =
-  config:
-    startInInsertMode:
-      type: 'boolean'
-      default: false
-    useSmartcaseForSearch:
-      type: 'boolean'
-      default: false
-    wrapLeftRightMotion:
-      type: 'boolean'
-      default: false
+  config: settings.config
 
   activate: (state) ->
     @disposables = new CompositeDisposable

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -1,6 +1,7 @@
 _ = require 'underscore-plus'
 {Point, Range} = require 'atom'
 {Emitter, Disposable, CompositeDisposable} = require 'event-kit'
+settings = require './settings'
 
 Operators = require './operators/index'
 Prefixes = require './prefixes'
@@ -34,7 +35,7 @@ class VimState
 
     @editorElement.classList.add("vim-mode")
     @setupCommandMode()
-    if atom.config.get 'vim-mode.startInInsertMode'
+    if settings.startInInsertMode()
       @activateInsertMode()
     else
       @activateCommandMode()

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -561,6 +561,13 @@ describe "Operators", ->
       it "leaves the cursor at the starting position", ->
         expect(editor.getCursorScreenPosition()).toEqual [0, 4]
 
+    describe "when useClipboardAsDefaultRegister enabled", ->
+      it "writes to clipboard", ->
+        atom.config.set 'vim-mode.useClipboardAsDefaultRegister', true
+        keydown('y')
+        keydown('y')
+        expect(atom.clipboard.read()).toBe '012 345\n'
+
     describe "when followed with a repeated y", ->
       beforeEach ->
         keydown('y')
@@ -734,6 +741,7 @@ describe "Operators", ->
         editor.setCursorScreenPosition [0, 0]
         vimState.setRegister('"', text: '345')
         vimState.setRegister('a', text: 'a')
+        atom.clipboard.write "clip"
 
       describe "from the default register", ->
         beforeEach -> keydown('p')
@@ -741,6 +749,12 @@ describe "Operators", ->
         it "inserts the contents", ->
           expect(editor.getText()).toBe "034512\n"
           expect(editor.getCursorScreenPosition()).toEqual [0, 3]
+
+      describe "when useClipboardAsDefaultRegister enabled", ->
+        it "inserts contents from clipboard", ->
+          atom.config.set 'vim-mode.useClipboardAsDefaultRegister', true
+          keydown('p')
+          expect(editor.getText()).toBe "0clip12\n"
 
       describe "from a specified register", ->
         beforeEach ->


### PR DESCRIPTION
I find it much nicer to have the default register mapped to the clipboard for better interop with the standard editor world, so this PR adds a new option to enable that behaviour.

It also moves the settings into their own module to serve a single point for defining options and any associated lookup functions.

Related:  #308