### PR TITLE
feature: VIM whichwrap

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -12,4 +12,4 @@
   * What Doesn't Exist:
     * default buffer doesn't yet save on delete operations.
     * `A-Z` - Appending via upper case registers
-* Setting `wrapHLMotion` acts like VIM's whichwrap=h,l
+* Setting `wrapLeftRightMotion` acts like VIM's whichwrap=h,l,<,>

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -12,3 +12,4 @@
   * What Doesn't Exist:
     * default buffer doesn't yet save on delete operations.
     * `A-Z` - Appending via upper case registers
+* Setting `wrapHLMotion` acts like VIM's whichwrap=h,l

--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -150,7 +150,7 @@ class MoveRight extends Motion
   moveCursor: (cursor, count=1) ->
     _.times count, =>
       cursor.moveRight() unless cursor.isAtEndOfLine()
-      cursor.moveRight() if cursor.isAtEndOfLine() and atom.config.get('vim-mode.wrapLeftRightMotion')
+      cursor.moveRight() if atom.config.get('vim-mode.wrapLeftRightMotion') and cursor.isAtEndOfLine()
       @ensureCursorIsWithinLine(cursor)
 
 class MoveUp extends Motion

--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -141,7 +141,7 @@ class MoveLeft extends Motion
 
   moveCursor: (cursor, count=1) ->
     _.times count, =>
-      cursor.moveLeft() unless cursor.isAtBeginningOfLine() and !atom.config.get('vim-mode.wrapLeftRightMotion')
+      cursor.moveLeft() unless cursor.isAtBeginningOfLine() and not atom.config.get('vim-mode.wrapLeftRightMotion')
       @ensureCursorIsWithinLine(cursor)
 
 class MoveRight extends Motion

--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -141,7 +141,7 @@ class MoveLeft extends Motion
 
   moveCursor: (cursor, count=1) ->
     _.times count, =>
-      cursor.moveLeft() unless cursor.isAtBeginningOfLine() and !atom.config.get('vim-mode.wrapHLMotion')
+      cursor.moveLeft() unless cursor.isAtBeginningOfLine() and !atom.config.get('vim-mode.wrapLeftRightMotion')
       @ensureCursorIsWithinLine(cursor)
 
 class MoveRight extends Motion
@@ -150,7 +150,7 @@ class MoveRight extends Motion
   moveCursor: (cursor, count=1) ->
     _.times count, =>
       cursor.moveRight() unless cursor.isAtEndOfLine()
-      cursor.moveRight() if cursor.isAtEndOfLine() and atom.config.get('vim-mode.wrapHLMotion')
+      cursor.moveRight() if cursor.isAtEndOfLine() and atom.config.get('vim-mode.wrapLeftRightMotion')
       @ensureCursorIsWithinLine(cursor)
 
 class MoveUp extends Motion

--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -141,7 +141,7 @@ class MoveLeft extends Motion
 
   moveCursor: (cursor, count=1) ->
     _.times count, =>
-      cursor.moveLeft() unless cursor.isAtBeginningOfLine() and not atom.config.get('vim-mode.wrapLeftRightMotion')
+      cursor.moveLeft() if not cursor.isAtBeginningOfLine() or atom.config.get('vim-mode.wrapLeftRightMotion')
       @ensureCursorIsWithinLine(cursor)
 
 class MoveRight extends Motion

--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -140,9 +140,9 @@ class MoveLeft extends Motion
   operatesInclusively: false
 
   moveCursor: (cursor, count=1) ->
-    _.times count, ->
-      unless cursor.isAtBeginningOfLine()
-        cursor.moveLeft()
+    _.times count, =>
+      cursor.moveLeft() unless cursor.isAtBeginningOfLine() and !atom.config.get('vim-mode.wrapHLMotion')
+      @ensureCursorIsWithinLine(cursor)
 
 class MoveRight extends Motion
   operatesInclusively: false
@@ -150,6 +150,7 @@ class MoveRight extends Motion
   moveCursor: (cursor, count=1) ->
     _.times count, =>
       cursor.moveRight() unless cursor.isAtEndOfLine()
+      cursor.moveRight() if cursor.isAtEndOfLine() and atom.config.get('vim-mode.wrapHLMotion')
       @ensureCursorIsWithinLine(cursor)
 
 class MoveUp extends Motion

--- a/lib/vim-mode.coffee
+++ b/lib/vim-mode.coffee
@@ -11,7 +11,7 @@ module.exports =
     useSmartcaseForSearch:
       type: 'boolean'
       default: false
-    wrapHLMotion:
+    wrapLeftRightMotion:
       type: 'boolean'
       default: false
 

--- a/lib/vim-mode.coffee
+++ b/lib/vim-mode.coffee
@@ -11,6 +11,9 @@ module.exports =
     useSmartcaseForSearch:
       type: 'boolean'
       default: false
+    wrapHLMotion:
+      type: 'boolean'
+      default: false
 
   activate: (state) ->
     @disposables = new CompositeDisposable

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -37,6 +37,12 @@ describe "Motions", ->
           keydown('h')
           expect(editor.getCursorScreenPosition()).toEqual [1, 0]
 
+        it "moves the cursor to the previous line if wrapHLMotion is true", ->
+          atom.config.set('vim-mode.wrapHLMotion', true)
+          keydown('h')
+          keydown('h')
+          expect(editor.getCursorScreenPosition()).toEqual [0, 4]
+
       describe "as a selection", ->
         it "selects the character to the left", ->
           keydown('y')
@@ -95,6 +101,12 @@ describe "Motions", ->
 
     describe "the l keybinding", ->
       beforeEach -> editor.setCursorScreenPosition([1, 2])
+
+      it "moves the cursor to the next line if wrapHLMotion is true", ->
+        atom.config.set('vim-mode.wrapHLMotion', true)
+        keydown('l')
+        keydown('l')
+        expect(editor.getCursorScreenPosition()).toEqual [2, 0]
 
       it "moves the cursor right, but not to the next line", ->
         keydown('l')

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -37,8 +37,8 @@ describe "Motions", ->
           keydown('h')
           expect(editor.getCursorScreenPosition()).toEqual [1, 0]
 
-        it "moves the cursor to the previous line if wrapHLMotion is true", ->
-          atom.config.set('vim-mode.wrapHLMotion', true)
+        it "moves the cursor to the previous line if wrapLeftRightMotion is true", ->
+          atom.config.set('vim-mode.wrapLeftRightMotion', true)
           keydown('h')
           keydown('h')
           expect(editor.getCursorScreenPosition()).toEqual [0, 4]
@@ -102,8 +102,8 @@ describe "Motions", ->
     describe "the l keybinding", ->
       beforeEach -> editor.setCursorScreenPosition([1, 2])
 
-      it "moves the cursor to the next line if wrapHLMotion is true", ->
-        atom.config.set('vim-mode.wrapHLMotion', true)
+      it "moves the cursor to the next line if wrapLeftRightMotion is true", ->
+        atom.config.set('vim-mode.wrapLeftRightMotion', true)
         keydown('l')
         keydown('l')
         expect(editor.getCursorScreenPosition()).toEqual [2, 0]

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -102,18 +102,18 @@ describe "Motions", ->
     describe "the l keybinding", ->
       beforeEach -> editor.setCursorScreenPosition([1, 2])
 
-      it "moves the cursor to the next line if wrapLeftRightMotion is true", ->
-        atom.config.set('vim-mode.wrapLeftRightMotion', true)
-        keydown('l')
-        keydown('l')
-        expect(editor.getCursorScreenPosition()).toEqual [2, 0]
-
       it "moves the cursor right, but not to the next line", ->
         keydown('l')
         expect(editor.getCursorScreenPosition()).toEqual [1, 3]
 
         keydown('l')
         expect(editor.getCursorScreenPosition()).toEqual [1, 3]
+
+      it "moves the cursor to the next line if wrapLeftRightMotion is true", ->
+        atom.config.set('vim-mode.wrapLeftRightMotion', true)
+        keydown('l')
+        keydown('l')
+        expect(editor.getCursorScreenPosition()).toEqual [2, 0]
 
       describe "on a blank line", ->
         it "doesn't move the cursor", ->


### PR DESCRIPTION
Hi, 
VIM has the `whichwrap` setting that allows wrapping some operations across line boundaries. I have now added wrapping of left and right motion (VIM values h,l,<,>) for myself because I use it heavily; I'm submitting it here for your consideration.

I know that this particular setting for `h` and `l` is "not recommended" in VIM, but the reasons for it that I could find are to do with plugins expecting the non-wrapping behavior – does anybody here know of actual problems with wrapping `h`,`l`, especially if they would translate to vim-mode in Atom?

Note that the VIM whichwrap settings `b`, `[` and `]` are already the standard behaviour in Atom vim-mode. The remaining settings `s` and `~` I don't really care about.