### PR TITLE
Fix repeated find motion

### DIFF
--- a/lib/motions/find-motion.coffee
+++ b/lib/motions/find-motion.coffee
@@ -17,6 +17,7 @@ class Find extends MotionWithInput
     if @backwards
       index = currentPosition.column
       for i in [0..count-1]
+        return if index <= 0 # we can't move backwards any further, quick return
         index = line.lastIndexOf(@input.characters, index-1)
       if index >= 0
         new Point(currentPosition.row, index + @offset)
@@ -24,6 +25,7 @@ class Find extends MotionWithInput
       index = currentPosition.column
       for i in [0..count-1]
         index = line.indexOf(@input.characters, index+1)
+        return if index < 0 # no match found
       if index >= 0
         new Point(currentPosition.row, index - @offset)
 

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -1413,6 +1413,12 @@ describe "Motions", ->
       keydown('f')
       commandModeInputKeydown('a')
       expect(editor.getCursorScreenPosition()).toEqual [0, 0]
+      # bug was making this behaviour depend on the number
+      keydown('1')
+      keydown('1')
+      keydown('f')
+      commandModeInputKeydown('a')
+      expect(editor.getCursorScreenPosition()).toEqual [0, 0]
 
     it "composes with d", ->
       editor.setCursorScreenPosition([0,3])
@@ -1459,6 +1465,11 @@ describe "Motions", ->
     it "doesn't move if there aren't the specified count of the specified character", ->
       keydown('1')
       keydown('0')
+      keydown('t')
+      commandModeInputKeydown('a')
+      expect(editor.getCursorScreenPosition()).toEqual [0, 0]
+      keydown('1')
+      keydown('1')
       keydown('t')
       commandModeInputKeydown('a')
       expect(editor.getCursorScreenPosition()).toEqual [0, 0]

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -1413,12 +1413,24 @@ describe "Motions", ->
       keydown('f')
       commandModeInputKeydown('a')
       expect(editor.getCursorScreenPosition()).toEqual [0, 0]
-      # bug was making this behaviour depend on the number
+      # a bug was making this behaviour depend on the count
       keydown('1')
       keydown('1')
       keydown('f')
       commandModeInputKeydown('a')
       expect(editor.getCursorScreenPosition()).toEqual [0, 0]
+      # and backwards now
+      editor.setCursorScreenPosition([0, 6])
+      keydown('1')
+      keydown('0')
+      keydown('F', shift: true)
+      commandModeInputKeydown('a')
+      expect(editor.getCursorScreenPosition()).toEqual [0, 6]
+      keydown('1')
+      keydown('1')
+      keydown('F', shift: true)
+      commandModeInputKeydown('a')
+      expect(editor.getCursorScreenPosition()).toEqual [0, 6]
 
     it "composes with d", ->
       editor.setCursorScreenPosition([0,3])
@@ -1468,11 +1480,24 @@ describe "Motions", ->
       keydown('t')
       commandModeInputKeydown('a')
       expect(editor.getCursorScreenPosition()).toEqual [0, 0]
+      # a bug was making this behaviour depend on the count
       keydown('1')
       keydown('1')
       keydown('t')
       commandModeInputKeydown('a')
       expect(editor.getCursorScreenPosition()).toEqual [0, 0]
+      # and backwards now
+      editor.setCursorScreenPosition([0, 6])
+      keydown('1')
+      keydown('0')
+      keydown('T', shift: true)
+      commandModeInputKeydown('a')
+      expect(editor.getCursorScreenPosition()).toEqual [0, 6]
+      keydown('1')
+      keydown('1')
+      keydown('T', shift: true)
+      commandModeInputKeydown('a')
+      expect(editor.getCursorScreenPosition()).toEqual [0, 6]
 
     it "composes with d", ->
       editor.setCursorScreenPosition([0,3])


### PR DESCRIPTION
There was a bug that repeated f/t motion wouldn't get canceled if we tried to move too many times.

E.g. in the test string 'abcabcabcabc' with cursor at the start, the motion 11fa would actually jump to the second a; the old test didn't uncover it because, as it happened, 10fa jumped to the first 'a', so the cursor didn't move. It was because indexOf with a negative fromIndex simply searched the whole string again.

Then while testing the backward motion F/T, I found that if it so happens that the character we're looking for is at the beginning of the line, the motion would simply go there, and again wouldn't be canceled. That's because in lastIndexOf, a negative fromIndex is treated as 0 and the first character gets searched (where it shouldn't).

So here I fix both cases. Feel free to split the tests that have accumulated there.