### PR TITLE
till motion should be repeatable with ; (VIM default)

### DIFF
--- a/lib/motions/find-motion.coffee
+++ b/lib/motions/find-motion.coffee
@@ -10,6 +10,7 @@ class Find extends MotionWithInput
     @backwards = false
     @repeatReversed = false
     @offset = 0
+    @repeated = false
 
   match: (cursor, count) ->
     currentPosition = cursor.getBufferPosition()
@@ -17,13 +18,13 @@ class Find extends MotionWithInput
     if @backwards
       index = currentPosition.column
       for i in [0..count-1]
-        index = line.lastIndexOf(@input.characters, index-1)
+        index = line.lastIndexOf(@input.characters, index-1-(@offset*@repeated))
       if index >= 0
         new Point(currentPosition.row, index + @offset)
     else
       index = currentPosition.column
       for i in [0..count-1]
-        index = line.indexOf(@input.characters, index+1)
+        index = line.indexOf(@input.characters, index+1+(@offset*@repeated))
       if index >= 0
         new Point(currentPosition.row, index - @offset)
 
@@ -37,6 +38,7 @@ class Find extends MotionWithInput
 
   repeat: (opts={}) ->
     opts.reverse = !!opts.reverse
+    @repeated = true
     if opts.reverse isnt @repeatReversed
       @reverse()
       @repeatReversed = opts.reverse

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -1431,6 +1431,10 @@ describe "Motions", ->
       keydown('t')
       commandModeInputKeydown('a')
       expect(editor.getCursorScreenPosition()).toEqual [0, 2]
+      # or stays put when it's already there
+      keydown('t')
+      commandModeInputKeydown('a')
+      expect(editor.getCursorScreenPosition()).toEqual [0, 2]
 
     it 'moves backwards to the character after the first specified character it finds', ->
       editor.setCursorScreenPosition([0, 2])
@@ -1550,20 +1554,20 @@ describe "Motions", ->
       keydown(',')
       expect(editor.getCursorScreenPosition()).toEqual [0, 8]
 
-    it "repeat t in same direction (won't move)", ->
+    it "repeat t in same direction", ->
       keydown('t')
       commandModeInputKeydown('c')
       expect(editor.getCursorScreenPosition()).toEqual [0, 1]
       keydown(';')
-      expect(editor.getCursorScreenPosition()).toEqual [0, 1]
+      expect(editor.getCursorScreenPosition()).toEqual [0, 4]
 
-    it "repeat T in same direction (won't move)", ->
+    it "repeat T in same direction", ->
       editor.setCursorScreenPosition([0,10])
       keydown('T', shift: true)
       commandModeInputKeydown('c')
       expect(editor.getCursorScreenPosition()).toEqual [0, 9]
       keydown(';')
-      expect(editor.getCursorScreenPosition()).toEqual [0, 9]
+      expect(editor.getCursorScreenPosition()).toEqual [0, 6]
 
     it "repeat t in opposite direction first, and then reverse", ->
       editor.setCursorScreenPosition([0,3])


### PR DESCRIPTION
Hi,
VIM has the 'cpoptions' option that directs where VIM should behave like VI; one of the flags is ';':
```
		;	When using |,| or |;| to repeat the last |t| search
			and the cursor is right in front of the searched
			character, the cursor won't move. When not included,
			the cursor would skip over it and jump to the
			following occurrence.
```
This PR implements VIM default behavior where ';' after 't' **does move**.

I haven't realized until today that I've been used to VIM behaviour, as opposed to what VI would do. How about others? Which way would be better in atom/vim-mode?