### PR TITLE
Adds keymap for insert mode CTRL-U

### DIFF
--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -12,6 +12,7 @@
 
 'atom-text-editor.vim-mode.insert-mode':
   'ctrl-w': 'editor:delete-to-beginning-of-word'
+  'ctrl-u': 'editor:delete-to-beginning-of-line'
 
 'atom-text-editor.vim-mode:not(.insert-mode)':
   'h': 'vim-mode:move-left'


### PR DESCRIPTION
Maps i_CTRL-U to `editor:delete-to-beginning-of-line`

I will write a test for this tomorrow. :smile: 
