### PR TITLE
Adds keymap for insert mode CTRL-T and CTRL-D

### DIFF
--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -13,6 +13,7 @@
 'atom-text-editor.vim-mode.insert-mode':
   'ctrl-w': 'editor:delete-to-beginning-of-word'
   'ctrl-u': 'editor:delete-to-beginning-of-line'
+  'ctrl-t': 'editor:indent-selected-rows'
 
 'atom-text-editor.vim-mode:not(.insert-mode)':
   'h': 'vim-mode:move-left'

--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -14,6 +14,7 @@
   'ctrl-w': 'editor:delete-to-beginning-of-word'
   'ctrl-u': 'editor:delete-to-beginning-of-line'
   'ctrl-t': 'editor:indent-selected-rows'
+  'ctrl-d': 'editor:outdent-selected-rows'
 
 'atom-text-editor.vim-mode:not(.insert-mode)':
   'h': 'vim-mode:move-left'


### PR DESCRIPTION
These are standard vim mappings.

`ctrl-d` shadows `core:delete` (delete character to the right of cursor)
`ctrl-t` shadows `editor:transpose` (swaps character to the left of cursor with character on the right)

There are other ways to do the things that get shadowed that is as quick and easy in Vim-mode, but I understand if your reasoning behind this package conflicts with these two additions.

Again, no tests since these are only mappings and not new functionality. 