### PR TITLE
Publish vim-mode as an atom service

### DIFF
--- a/lib/vim-mode.coffee
+++ b/lib/vim-mode.coffee
@@ -9,23 +9,23 @@ module.exports =
 
   activate: (state) ->
     @disposables = new CompositeDisposable
-    globalVimState = new GlobalVimState
+    @globalVimState = new GlobalVimState
     @statusBarManager = new StatusBarManager
-    vimStates = new WeakMap
+    @vimStates = new WeakMap
 
     @disposables.add atom.workspace.observeTextEditors (editor) =>
       return if editor.mini
 
       element = atom.views.getView(editor)
 
-      if not vimStates.get(editor)
+      if not @vimStates.get(editor)
         vimState = new VimState(
           element,
           @statusBarManager,
-          globalVimState
+          @globalVimState
         )
 
-        vimStates.set(editor, vimState)
+        @vimStates.set(editor, vimState)
 
         @disposables.add new Disposable =>
           vimState.destroy()
@@ -33,8 +33,18 @@ module.exports =
   deactivate: ->
     @disposables.dispose()
 
+  getGlobalState: ->
+    @globalVimState
+
+  getEditorState: (editor) ->
+    @vimStates.get(editor)
+
   consumeStatusBar: (statusBar) ->
     @statusBarManager.initialize(statusBar)
     @statusBarManager.attach()
     @disposables.add new Disposable =>
       @statusBarManager.detach()
+
+  provideVimMode: ->
+    getGlobalState: @getGlobalState.bind(@)
+    getEditorState: @getEditorState.bind(@)

--- a/package.json
+++ b/package.json
@@ -19,5 +19,13 @@
         "^0.58.0": "consumeStatusBar"
       }
     }
+  },
+  "providedServices": {
+    "vim-mode": {
+      "description": "",
+      "versions": {
+        "0.1.0": "provideVimMode"
+      }
+    }
   }
 }


### PR DESCRIPTION
In response to #536.

This exposes `getState(editor)` along with `getGlobalState()` via a versioned `vim-mode` service. The consumer then has direct access to the editor's VimState instance. Therefore I made the service version equal to vim-mode's package version.

This will allow packages extending vim-mode to have access to its core state (such as registers, marks...) but also `pushOperations`, which offers a wealth of possibilities.

It may be advisable ultimately to box the VimState instance into a service proxy object, so as to expose a restricted and stable API, isolated from what amounts to the core of vim-mode. This may be too early though, as we may be too restrictive early on. I don't know what your versioning policy is, but this may be a worthy goal for vim-mode 1.0.