### PR TITLE
Use space-pen dependencies for input views

### DIFF
--- a/lib/view-models/vim-command-mode-input-view.coffee
+++ b/lib/view-models/vim-command-mode-input-view.coffee
@@ -1,4 +1,4 @@
-{View} = require 'space-pen'
+{View, $} = require 'space-pen'
 {TextEditorView} = require 'atom-space-pen-views'
 
 module.exports =
@@ -24,18 +24,20 @@ class VimCommandModeInputView extends View
     @handleEvents()
 
   handleEvents: ->
+    input = $ @editor[0].rootElement.querySelector 'input'
     if @singleChar?
-      @editor.find('input').on 'textInput', @autosubmit
+      input.on 'textInput', @autosubmit
     @editor.on 'core:confirm', @confirm
     @editor.on 'core:cancel', @cancel
-    @editor.find('input').on 'blur', @cancel
+    input.on 'blur', @cancel
 
   stopHandlingEvents: ->
+    input = $ @editor[0].rootElement.querySelector 'input'
     if @singleChar?
-      @editor.find('input').off 'textInput', @autosubmit
+      input.off 'textInput', @autosubmit
     @editor.off 'core:confirm', @confirm
     @editor.off 'core:cancel', @cancel
-    @editor.find('input').off 'blur', @cancel
+    input.off 'blur', @cancel
 
   autosubmit: (event) =>
     @editor.setText(event.originalEvent.data)

--- a/lib/view-models/vim-command-mode-input-view.coffee
+++ b/lib/view-models/vim-command-mode-input-view.coffee
@@ -1,4 +1,5 @@
-{View, TextEditorView} = require 'atom'
+{View} = require 'space-pen'
+{TextEditorView} = require 'atom-space-pen-views'
 
 module.exports =
 class VimCommandModeInputView extends View

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
     "atom": ">0.151.0"
   },
   "dependencies": {
-    "underscore-plus": "1.x",
-    "event-kit": "^0.7.2"
+    "atom-space-pen-views": "^2.0.4",
+    "event-kit": "^0.7.2",
+    "space-pen": "^5.1.1",
+    "underscore-plus": "1.x"
   },
   "consumedServices": {
     "status-bar": {

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -19,7 +19,7 @@ describe "Motions", ->
     helpers.keydown(key, options)
 
   commandModeInputKeydown = (key, opts = {}) ->
-    opts.element = editor.commandModeInputView.editor.find('input').get(0)
+    opts.element = editor.commandModeInputView.editor[0].rootElement.querySelector 'input'
     opts.raw = true
     keydown(key, opts)
 

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -19,7 +19,7 @@ describe "Motions", ->
     helpers.keydown(key, options)
 
   commandModeInputKeydown = (key, opts = {}) ->
-    opts.element = editor.commandModeInputView.editor[0].rootElement.querySelector 'input'
+    opts.element = helpers.getCommandModeInputElement editor
     opts.raw = true
     keydown(key, opts)
 

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -19,7 +19,7 @@ describe "Operators", ->
     helpers.keydown(key, options)
 
   commandModeInputKeydown = (key, opts = {}) ->
-    opts.element = editor.commandModeInputView.editor.find('input').get(0)
+    opts.element = editor.commandModeInputView.editor[0].rootElement.querySelector 'input'
     opts.raw = true
     keydown(key, opts)
 

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -19,7 +19,7 @@ describe "Operators", ->
     helpers.keydown(key, options)
 
   commandModeInputKeydown = (key, opts = {}) ->
-    opts.element = editor.commandModeInputView.editor[0].rootElement.querySelector 'input'
+    opts.element = helpers.getCommandModeInputElement editor
     opts.raw = true
     keydown(key, opts)
 

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -63,4 +63,13 @@ keydown = (key, {element, ctrl, shift, alt, meta, raw}={}) ->
        element.value += key
   dispatchKeyboardEvent(element, 'keyup', eventArgs...)
 
-module.exports = { keydown, getEditorElement, mockPlatform, unmockPlatform }
+getCommandModeInputElement = (editor) ->
+  editor.commandModeInputView.editor[0].rootElement.querySelector 'input'
+
+module.exports = {
+  keydown
+  getCommandModeInputElement
+  getEditorElement
+  mockPlatform
+  unmockPlatform
+}

--- a/spec/text-objects-spec.coffee
+++ b/spec/text-objects-spec.coffee
@@ -19,7 +19,7 @@ describe "TextObjects", ->
     helpers.keydown(key, options)
 
   commandModeInputKeydown = (key, opts = {}) ->
-    opts.element = editor.commandModeInputView.editor[0].rootElement.querySelector 'input'
+    opts.element = helpers.getCommandModeInputElement editor
     opts.raw = true
     keydown(key, opts)
 

--- a/spec/text-objects-spec.coffee
+++ b/spec/text-objects-spec.coffee
@@ -19,7 +19,7 @@ describe "TextObjects", ->
     helpers.keydown(key, options)
 
   commandModeInputKeydown = (key, opts = {}) ->
-    opts.element = editor.commandModeInputView.editor.find('input').get(0)
+    opts.element = editor.commandModeInputView.editor[0].rootElement.querySelector 'input'
     opts.raw = true
     keydown(key, opts)
 

--- a/spec/vim-state-spec.coffee
+++ b/spec/vim-state-spec.coffee
@@ -21,7 +21,7 @@ describe "VimState", ->
     helpers.keydown(key, options)
 
   commandModeInputKeydown = (key, opts = {}) ->
-    opts.element = editor.commandModeInputView.editor[0].rootElement.querySelector 'input'
+    opts.element = helpers.getCommandModeInputElement editor
     opts.raw = true
     keydown(key, opts)
 

--- a/spec/vim-state-spec.coffee
+++ b/spec/vim-state-spec.coffee
@@ -21,7 +21,7 @@ describe "VimState", ->
     helpers.keydown(key, options)
 
   commandModeInputKeydown = (key, opts = {}) ->
-    opts.element = editor.commandModeInputView.editor.find('input').get(0)
+    opts.element = editor.commandModeInputView.editor[0].rootElement.querySelector 'input'
     opts.raw = true
     keydown(key, opts)
 


### PR DESCRIPTION
This probably isn't the best way to fix this, the views seem to be deprecated. Not sure how to go about replacing the views with an `<atom-text-editor>` though

fixes #544