### PR TITLE
Add 'i t' for inside tags

### DIFF
--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -201,6 +201,7 @@
   'i B': 'vim-mode:select-inside-curly-brackets'
   'i <': 'vim-mode:select-inside-angle-brackets'
   'i >': 'vim-mode:select-inside-angle-brackets'
+  'i t': 'vim-mode:select-inside-tags'
   'i [': 'vim-mode:select-inside-square-brackets'
   'i ]': 'vim-mode:select-inside-square-brackets'
   'i (': 'vim-mode:select-inside-parentheses'

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -124,6 +124,7 @@ class VimState
       'select-inside-back-ticks': => new TextObjects.SelectInsideQuotes(@editor, '`', false)
       'select-inside-curly-brackets': => new TextObjects.SelectInsideBrackets(@editor, '{', '}', false)
       'select-inside-angle-brackets': => new TextObjects.SelectInsideBrackets(@editor, '<', '>', false)
+      'select-inside-tags': => new TextObjects.SelectInsideBrackets(@editor, '>', '<', false)
       'select-inside-square-brackets': => new TextObjects.SelectInsideBrackets(@editor, '[', ']', false)
       'select-inside-parentheses': => new TextObjects.SelectInsideBrackets(@editor, '(', ')', false)
       'select-a-word': => new TextObjects.SelectAWord(@editor)

--- a/spec/text-objects-spec.coffee
+++ b/spec/text-objects-spec.coffee
@@ -142,6 +142,30 @@ describe "TextObjects", ->
       expect(editorElement.classList.contains('operator-pending-mode')).toBe(false)
       expect(editorElement.classList.contains('command-mode')).toBe(true)
 
+  describe "the 'it' text object", ->
+    beforeEach ->
+      editor.setText("<something>here</something><again>")
+      editor.setCursorScreenPosition([0, 5])
+
+    it "applies only if in the value of a tag", ->
+      keydown('d')
+      keydown('i')
+      keydown('t')
+      expect(editor.getText()).toBe "<something>here</something><again>"
+      expect(editor.getCursorScreenPosition()).toEqual [0, 5]
+      expect(editorElement.classList.contains('operator-pending-mode')).toBe(false)
+      expect(editorElement.classList.contains('command-mode')).toBe(true)
+
+    it "applies operators inside the current word in operator-pending mode", ->
+      editor.setCursorScreenPosition([0, 13])
+      keydown('d')
+      keydown('i')
+      keydown('t')
+      expect(editor.getText()).toBe "<something></something><again>"
+      expect(editor.getCursorScreenPosition()).toEqual [0, 11]
+      expect(editorElement.classList.contains('operator-pending-mode')).toBe(false)
+      expect(editorElement.classList.contains('command-mode')).toBe(true)
+
   describe "the 'i[' text object", ->
     beforeEach ->
       editor.setText("[ something in here and in [here] ]")


### PR DESCRIPTION
I just :+1: #418 and thought I'd give a go at actually implementing it.

Hopefully code is straight forward.
It's not exactly like vim right now, if you're not inside a tag it won't do anything, vim is smart enough to move to the next tag and then do the action. However that seems to be how the other motions in atom are done right now anyway...