### PR TITLE
:bug: fix 'd' and 'c' sometimes deleting a char before cursor

### DIFF
--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -82,7 +82,7 @@ class Motion
 
       if (isReversed or isEmpty) and not (wasReversed or wasEmpty)
         selection.setBufferRange([newStart, [newEnd.row, oldStart.column + 1]])
-      if wasReversed and not isReversed
+      if wasReversed and not wasEmpty and not isReversed
         selection.setBufferRange([[newStart.row, oldEnd.column - 1], newEnd])
 
   moveSelection: (selection, count, options) ->

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -375,6 +375,21 @@ describe "Operators", ->
           keydown('G', shift: true)
           expect(editor.getText()).toBe("12345\nABCDE")
 
+    describe "when followed by a t)", ->
+      describe "with the entire line yanked before", ->
+        beforeEach ->
+          editor.setText("test (xyz)")
+          editor.setCursorScreenPosition([0, 6])
+
+        it "deletes until the closing parenthesis", ->
+          keydown('y')
+          keydown('y')
+          keydown('d')
+          keydown('t')
+          commandModeInputKeydown(')')
+          expect(editor.getText()).toBe("test ()")
+          expect(editor.getCursorScreenPosition()).toEqual [0, 6]
+
     describe "with multiple cursors", ->
       it "deletes each selection", ->
         editor.setText("abcd\n1234\nABCD")


### PR DESCRIPTION
This fixes #543

For some reason having yanked the whole line before the delete + motion made the wasReversed variable be true (it was false without the yank)