### PR TITLE
fix wrapping behavior of x

### DIFF
--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -149,10 +149,16 @@ class MoveLeft extends Motion
 class MoveRight extends Motion
   operatesInclusively: false
 
-  moveCursor: (cursor, count=1) ->
+  # MoveRight can be combined with Delete, which will indicate it by the presence of options.deleting
+  moveCursor: (cursor, count=1, options={}) ->
     _.times count, =>
-      cursor.moveRight() unless cursor.isAtEndOfLine()
-      cursor.moveRight() if settings.wrapLeftRightMotion() and cursor.isAtEndOfLine()
+      goingToNextLine = atom.config.get('vim-mode.wrapLeftRightMotion')
+
+      if not cursor.isAtEndOfLine() # the line is not empty
+        cursor.moveRight()
+        goingToNextLine = false if options.deleting # when deleting, wrapLeftRightMotion only works on an empty line
+
+      cursor.moveRight() if cursor.isAtEndOfLine() and goingToNextLine
       @ensureCursorIsWithinLine(cursor)
 
 class MoveUp extends Motion

--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -149,16 +149,16 @@ class MoveLeft extends Motion
 class MoveRight extends Motion
   operatesInclusively: false
 
-  # MoveRight can be combined with Delete, which will indicate it by the presence of options.deleting
   moveCursor: (cursor, count=1, options={}) ->
     _.times count, =>
-      goingToNextLine = settings.wrapLeftRightMotion()
+      wrapToNextLine = settings.wrapLeftRightMotion()
 
-      if not cursor.isAtEndOfLine() # the line is not empty
-        cursor.moveRight()
-        goingToNextLine = false if options.deleting # when deleting, wrapLeftRightMotion only works on an empty line
+      # when the motion is combined with an operator, we will only wrap to the next line
+      # if we are already at the end of the line (after the last character)
+      wrapToNextLine = false if @vimState.mode is 'operator-pending' and not cursor.isAtEndOfLine()
 
-      cursor.moveRight() if cursor.isAtEndOfLine() and goingToNextLine
+      cursor.moveRight() unless cursor.isAtEndOfLine()
+      cursor.moveRight() if wrapToNextLine and cursor.isAtEndOfLine()
       @ensureCursorIsWithinLine(cursor)
 
 class MoveUp extends Motion

--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -149,7 +149,7 @@ class MoveLeft extends Motion
 class MoveRight extends Motion
   operatesInclusively: false
 
-  moveCursor: (cursor, count=1, options={}) ->
+  moveCursor: (cursor, count=1) ->
     _.times count, =>
       wrapToNextLine = settings.wrapLeftRightMotion()
 

--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -152,7 +152,7 @@ class MoveRight extends Motion
   # MoveRight can be combined with Delete, which will indicate it by the presence of options.deleting
   moveCursor: (cursor, count=1, options={}) ->
     _.times count, =>
-      goingToNextLine = atom.config.get('vim-mode.wrapLeftRightMotion')
+      goingToNextLine = settings.wrapLeftRightMotion()
 
       if not cursor.isAtEndOfLine() # the line is not empty
         cursor.moveRight()

--- a/lib/operators/general-operators.coffee
+++ b/lib/operators/general-operators.coffee
@@ -84,7 +84,6 @@ class Delete extends Operator
     @complete = false
     @selectOptions ?= {}
     @selectOptions.requireEOL ?= true
-    @selectOptions.deleting ?= true
     @register = settings.defaultRegister()
 
   # Public: Deletes the text selected by the given motion.

--- a/lib/operators/general-operators.coffee
+++ b/lib/operators/general-operators.coffee
@@ -84,6 +84,7 @@ class Delete extends Operator
     @complete = false
     @selectOptions ?= {}
     @selectOptions.requireEOL ?= true
+    @selectOptions.deleting ?= true
     @register = settings.defaultRegister()
 
   # Public: Deletes the text selected by the given motion.
@@ -100,7 +101,7 @@ class Delete extends Operator
         if @motion.isLinewise?()
           cursor.moveToBeginningOfLine()
         else
-          cursor.moveLeft() if cursor.isAtEndOfLine()
+          cursor.moveLeft() if cursor.isAtEndOfLine() and not cursor.isAtBeginningOfLine()
 
     @vimState.activateCommandMode()
 

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -377,6 +377,9 @@ class VimState
 
     @clearOpStack()
     selection.clear(autoscroll: false) for selection in @editor.getSelections()
+    for cursor in @editor.getCursors()
+      if cursor.isAtEndOfLine() and not cursor.isAtBeginningOfLine()
+        cursor.moveLeft()
 
     @updateStatusBar()
 

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -37,65 +37,179 @@ describe "Operators", ->
 
   describe "the x keybinding", ->
     describe "on a line with content", ->
-      beforeEach ->
-        editor.setText("012345")
-        editor.setCursorScreenPosition([0, 4])
+      describe "without vim-mode.wrapLeftRightMotion", ->
+        beforeEach ->
+          editor.setText("abc\n012345\n\nxyz")
+          editor.setCursorScreenPosition([1, 4])
 
-      it "deletes a character", ->
-        keydown('x')
-        expect(editor.getText()).toBe '01235'
-        expect(editor.getCursorScreenPosition()).toEqual [0, 4]
-        expect(vimState.getRegister('"').text).toBe '4'
+        it "deletes a character", ->
+          keydown('x')
+          expect(editor.getText()).toBe 'abc\n01235\n\nxyz'
+          expect(editor.getCursorScreenPosition()).toEqual [1, 4]
+          expect(vimState.getRegister('"').text).toBe '4'
 
-        keydown('x')
-        expect(editor.getText()).toBe '0123'
-        expect(editor.getCursorScreenPosition()).toEqual [0, 3]
-        expect(vimState.getRegister('"').text).toBe '5'
+          keydown('x')
+          expect(editor.getText()).toBe 'abc\n0123\n\nxyz'
+          expect(editor.getCursorScreenPosition()).toEqual [1, 3]
+          expect(vimState.getRegister('"').text).toBe '5'
 
-        keydown('x')
-        expect(editor.getText()).toBe '012'
-        expect(editor.getCursorScreenPosition()).toEqual [0, 2]
-        expect(vimState.getRegister('"').text).toBe '3'
+          keydown('x')
+          expect(editor.getText()).toBe 'abc\n012\n\nxyz'
+          expect(editor.getCursorScreenPosition()).toEqual [1, 2]
+          expect(vimState.getRegister('"').text).toBe '3'
+
+          keydown('x')
+          expect(editor.getText()).toBe 'abc\n01\n\nxyz'
+          expect(editor.getCursorScreenPosition()).toEqual [1, 1]
+          expect(vimState.getRegister('"').text).toBe '2'
+
+          keydown('x')
+          expect(editor.getText()).toBe 'abc\n0\n\nxyz'
+          expect(editor.getCursorScreenPosition()).toEqual [1, 0]
+          expect(vimState.getRegister('"').text).toBe '1'
+
+          keydown('x')
+          expect(editor.getText()).toBe 'abc\n\n\nxyz'
+          expect(editor.getCursorScreenPosition()).toEqual [1, 0]
+          expect(vimState.getRegister('"').text).toBe '0'
+
+        it "deletes multiple characters with a count", ->
+          keydown('2')
+          keydown('x')
+          expect(editor.getText()).toBe 'abc\n0123\n\nxyz'
+          expect(editor.getCursorScreenPosition()).toEqual [1, 3]
+          expect(vimState.getRegister('"').text).toBe '45'
+
+          editor.setCursorScreenPosition([0, 1])
+          keydown('3')
+          keydown('x')
+          expect(editor.getText()).toBe 'a\n0123\n\nxyz'
+          expect(editor.getCursorScreenPosition()).toEqual [0, 0]
+          expect(vimState.getRegister('"').text).toBe 'bc'
+
+      describe "with vim-mode.wrapLeftRightMotion", ->
+        beforeEach ->
+          editor.setText("abc\n012345\n\nxyz")
+          editor.setCursorScreenPosition([1, 4])
+          atom.config.set('vim-mode.wrapLeftRightMotion', true)
+
+        it "deletes a character", ->
+          # copy of the earlier test because wrapLeftRightMotion should not affect it
+          keydown('x')
+          expect(editor.getText()).toBe 'abc\n01235\n\nxyz'
+          expect(editor.getCursorScreenPosition()).toEqual [1, 4]
+          expect(vimState.getRegister('"').text).toBe '4'
+
+          keydown('x')
+          expect(editor.getText()).toBe 'abc\n0123\n\nxyz'
+          expect(editor.getCursorScreenPosition()).toEqual [1, 3]
+          expect(vimState.getRegister('"').text).toBe '5'
+
+          keydown('x')
+          expect(editor.getText()).toBe 'abc\n012\n\nxyz'
+          expect(editor.getCursorScreenPosition()).toEqual [1, 2]
+          expect(vimState.getRegister('"').text).toBe '3'
+
+          keydown('x')
+          expect(editor.getText()).toBe 'abc\n01\n\nxyz'
+          expect(editor.getCursorScreenPosition()).toEqual [1, 1]
+          expect(vimState.getRegister('"').text).toBe '2'
+
+          keydown('x')
+          expect(editor.getText()).toBe 'abc\n0\n\nxyz'
+          expect(editor.getCursorScreenPosition()).toEqual [1, 0]
+          expect(vimState.getRegister('"').text).toBe '1'
+
+          keydown('x')
+          expect(editor.getText()).toBe 'abc\n\n\nxyz'
+          expect(editor.getCursorScreenPosition()).toEqual [1, 0]
+          expect(vimState.getRegister('"').text).toBe '0'
+
+        it "deletes multiple characters and newlines with a count", ->
+          atom.config.set('vim-mode.wrapLeftRightMotion', true)
+          keydown('2')
+          keydown('x')
+          expect(editor.getText()).toBe 'abc\n0123\n\nxyz'
+          expect(editor.getCursorScreenPosition()).toEqual [1, 3]
+          expect(vimState.getRegister('"').text).toBe '45'
+
+          editor.setCursorScreenPosition([0, 1])
+          keydown('3')
+          keydown('x')
+          expect(editor.getText()).toBe 'a0123\n\nxyz'
+          expect(editor.getCursorScreenPosition()).toEqual [0, 1]
+          expect(vimState.getRegister('"').text).toBe 'bc\n'
+
+          keydown('7')
+          keydown('x')
+          expect(editor.getText()).toBe 'ayz'
+          expect(editor.getCursorScreenPosition()).toEqual [0, 1]
+          expect(vimState.getRegister('"').text).toBe '0123\n\nx'
+
 
     describe "on an empty line", ->
       beforeEach ->
-        editor.setText("012345\n\nabcdef")
-        editor.setCursorScreenPosition([1, 0])
-        keydown('x')
+        editor.setText("abc\n012345\n\nxyz")
+        editor.setCursorScreenPosition([2, 0])
 
-      it "deletes nothing when cursor is on empty line", ->
-        expect(editor.getText()).toBe "012345\n\nabcdef"
+      it "deletes nothing on an empty line when vim-mode.wrapLeftRightMotion is false", ->
+        atom.config.set('vim-mode.wrapLeftRightMotion', false)
+        keydown('x')
+        expect(editor.getText()).toBe "abc\n012345\n\nxyz"
+        expect(editor.getCursorScreenPosition()).toEqual [2, 0]
+
+      it "deletes an empty line when vim-mode.wrapLeftRightMotion is true", ->
+        atom.config.set('vim-mode.wrapLeftRightMotion', true)
+        keydown('x')
+        expect(editor.getText()).toBe "abc\n012345\nxyz"
+        expect(editor.getCursorScreenPosition()).toEqual [2, 0]
+
 
   describe "the X keybinding", ->
     describe "on a line with content", ->
       beforeEach ->
-        editor.setText("012345")
-        editor.setCursorScreenPosition([0, 2])
+        editor.setText("ab\n012345")
+        editor.setCursorScreenPosition([1, 2])
 
       it "deletes a character", ->
         keydown('X', shift: true)
-        expect(editor.getText()).toBe '02345'
-        expect(editor.getCursorScreenPosition()).toEqual [0, 1]
+        expect(editor.getText()).toBe 'ab\n02345'
+        expect(editor.getCursorScreenPosition()).toEqual [1, 1]
         expect(vimState.getRegister('"').text).toBe '1'
 
         keydown('X', shift: true)
-        expect(editor.getText()).toBe '2345'
-        expect(editor.getCursorScreenPosition()).toEqual [0, 0]
+        expect(editor.getText()).toBe 'ab\n2345'
+        expect(editor.getCursorScreenPosition()).toEqual [1, 0]
         expect(vimState.getRegister('"').text).toBe '0'
 
         keydown('X', shift: true)
-        expect(editor.getText()).toBe '2345'
-        expect(editor.getCursorScreenPosition()).toEqual [0, 0]
+        expect(editor.getText()).toBe 'ab\n2345'
+        expect(editor.getCursorScreenPosition()).toEqual [1, 0]
         expect(vimState.getRegister('"').text).toBe '0'
+
+        atom.config.set('vim-mode.wrapLeftRightMotion', true)
+        keydown('X', shift: true)
+        expect(editor.getText()).toBe 'ab2345'
+        expect(editor.getCursorScreenPosition()).toEqual [0, 2]
+        expect(vimState.getRegister('"').text).toBe '\n'
+
 
     describe "on an empty line", ->
       beforeEach ->
         editor.setText("012345\n\nabcdef")
         editor.setCursorScreenPosition([1, 0])
-        keydown('X', shift: true)
 
-      it "deletes nothing when cursor is on empty line", ->
+      it "deletes nothing when vim-mode.wrapLeftRightMotion is false", ->
+        atom.config.set('vim-mode.wrapLeftRightMotion', false)
+        keydown('X', shift: true)
         expect(editor.getText()).toBe "012345\n\nabcdef"
+        expect(editor.getCursorScreenPosition()).toEqual [1, 0]
+
+      it "deletes the newline when wrapLeftRightMotion is true", ->
+        atom.config.set('vim-mode.wrapLeftRightMotion', true)
+        keydown('X', shift: true)
+        expect(editor.getText()).toBe "012345\nabcdef"
+        expect(editor.getCursorScreenPosition()).toEqual [0, 5]
 
   describe "the s keybinding", ->
     beforeEach ->


### PR DESCRIPTION
`x` should only wrap to next line with `vim-mode.wrapLeftRightMotion = true`, and only with a count or on an empty line.
The PR also adds a bit to the tests for X.