### PR TITLE
:feature: `U` and `u` for upper-casing and lower-casing

### DIFF
--- a/docs/operators.md
+++ b/docs/operators.md
@@ -36,3 +36,7 @@
   * `J` - joins the current line with the immediately following line.
 * [Mark](http://vimhelp.appspot.com/motion.txt.html#m)
   * `m[a-z][A-Z]` - marks the current cursor position
+* [Case](http://vimhelp.appspot.com/motion.txt.html#operator)
+  * `~` or `g~` - toggles case
+  * `gU`, or `U` in visual mode - changes to upper case
+  * `gu`, or `u` in visual mode - changes to lower case

--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -80,9 +80,10 @@
   'P': 'vim-mode:put-before'
   'p': 'vim-mode:put-after'
 
-  '~': 'vim-mode:toggle-case'
+  'g ~': 'vim-mode:toggle-case'
   'g U': 'vim-mode:upper-case'
   'g u': 'vim-mode:lower-case'
+  '~': 'vim-mode:toggle-case-now'
 
   'ctrl-w ctrl-h': 'vim-mode:focus-pane-view-on-left'
   'ctrl-w h': 'vim-mode:focus-pane-view-on-left'

--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -227,3 +227,4 @@
   'x': 'vim-mode:delete'
   's': 'vim-mode:change'
   'o': 'vim-mode:reverse-selections'
+  'U': 'vim-mode:upper-case'

--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -81,6 +81,8 @@
   'p': 'vim-mode:put-after'
 
   '~': 'vim-mode:toggle-case'
+  'g U': 'vim-mode:upper-case'
+  'g u': 'vim-mode:lower-case'
 
   'ctrl-w ctrl-h': 'vim-mode:focus-pane-view-on-left'
   'ctrl-w h': 'vim-mode:focus-pane-view-on-left'
@@ -228,3 +230,4 @@
   's': 'vim-mode:change'
   'o': 'vim-mode:reverse-selections'
   'U': 'vim-mode:upper-case'
+  'u': 'vim-mode:lower-case'

--- a/lib/operators/general-operators.coffee
+++ b/lib/operators/general-operators.coffee
@@ -111,7 +111,7 @@ class ToggleCase extends Operator
   constructor: (@editor, @vimState, {@complete, @selectOptions}={}) ->
 
   execute: (count=1) ->
-    if @motion
+    if @motion?
       if _.contains(@motion.select(count, @selectOptions), true)
         @editor.replaceSelectedText {}, (text) ->
           text.split('').map((char) ->

--- a/lib/operators/general-operators.coffee
+++ b/lib/operators/general-operators.coffee
@@ -108,19 +108,19 @@ class Delete extends Operator
 # It toggles the case of everything selected by the following motion
 #
 class ToggleCase extends Operator
-  constructor: (@editor, @vimState, {@selectOptions}={}) ->
-    @complete = true
+  constructor: (@editor, @vimState, {@complete, @selectOptions}={}) ->
 
   execute: (count=1) ->
-    if @vimState.mode is 'visual'
-      @editor.replaceSelectedText {}, (text) ->
-        text.split('').map((char) ->
-          lower = char.toLowerCase()
-          if char is lower
-            char.toUpperCase()
-          else
-            lower
-        ).join('')
+    if @motion
+      if _.contains(@motion.select(count, @selectOptions), true)
+        @editor.replaceSelectedText {}, (text) ->
+          text.split('').map((char) ->
+            lower = char.toLowerCase()
+            if char is lower
+              char.toUpperCase()
+            else
+              lower
+          ).join('')
     else
       @editor.transact =>
         for cursor in @editor.getCursors()
@@ -143,56 +143,30 @@ class ToggleCase extends Operator
     @vimState.activateCommandMode()
 
 #
-# In visual mode or after `g`, it makes the selection uppercase
+# In visual mode or after `g` with a motion, it makes the selection uppercase
 #
 class UpperCase extends Operator
   constructor: (@editor, @vimState, {@selectOptions}={}) ->
-    @complete = true
+    @complete = false
 
   execute: (count=1) ->
-    if @vimState.mode is 'visual'
+    if _.contains(@motion.select(count, @selectOptions), true)
       @editor.replaceSelectedText {}, (text) ->
         text.toUpperCase()
-    else
-      @editor.transact =>
-        for cursor in @editor.getCursors()
-          point = cursor.getBufferPosition()
-          lineLength = @editor.lineTextForBufferRow(point.row).length
-          cursorCount = Math.min(count, lineLength - point.column)
-
-          _.times cursorCount, =>
-            point = cursor.getBufferPosition()
-            range = Range.fromPointWithDelta(point, 0, 1)
-            char = @editor.getTextInBufferRange(range)
-            @editor.setTextInBufferRange(range, char.toUpperCase())
-            cursor.moveRight() unless point.column >= lineLength - 1
 
     @vimState.activateCommandMode()
 
 #
-# In visual mode or after `g`, it makes the selection lowercase
+# In visual mode or after `g` with a motion, it makes the selection lowercase
 #
 class LowerCase extends Operator
   constructor: (@editor, @vimState, {@selectOptions}={}) ->
-    @complete = true
+    @complete = false
 
   execute: (count=1) ->
-    if @vimState.mode is 'visual'
+    if _.contains(@motion.select(count, @selectOptions), true)
       @editor.replaceSelectedText {}, (text) ->
         text.toLowerCase()
-    else
-      @editor.transact =>
-        for cursor in @editor.getCursors()
-          point = cursor.getBufferPosition()
-          lineLength = @editor.lineTextForBufferRow(point.row).length
-          cursorCount = Math.min(count, lineLength - point.column)
-
-          _.times cursorCount, =>
-            point = cursor.getBufferPosition()
-            range = Range.fromPointWithDelta(point, 0, 1)
-            char = @editor.getTextInBufferRange(range)
-            @editor.setTextInBufferRange(range, char.toLowerCase())
-            cursor.moveRight() unless point.column >= lineLength - 1
 
     @vimState.activateCommandMode()
 

--- a/lib/operators/general-operators.coffee
+++ b/lib/operators/general-operators.coffee
@@ -143,6 +143,33 @@ class ToggleCase extends Operator
     @vimState.activateCommandMode()
 
 #
+# In visual mode, it makes the selection uppercase
+#
+class UpperCase extends Operator
+  constructor: (@editor, @vimState, {@selectOptions}={}) ->
+    @complete = true
+
+  execute: (count=1) ->
+    if @vimState.mode is 'visual'
+      @editor.replaceSelectedText {}, (text) ->
+        text.toUpperCase()
+    else
+      @editor.transact =>
+        for cursor in @editor.getCursors()
+          point = cursor.getBufferPosition()
+          lineLength = @editor.lineTextForBufferRow(point.row).length
+          cursorCount = Math.min(count, lineLength - point.column)
+
+          _.times cursorCount, =>
+            point = cursor.getBufferPosition()
+            range = Range.fromPointWithDelta(point, 0, 1)
+            char = @editor.getTextInBufferRange(range)
+            @editor.setTextInBufferRange(range, char.toUpperCase())
+            cursor.moveRight() unless point.column >= lineLength - 1
+
+    @vimState.activateCommandMode()
+
+#
 # It copies everything selected by the following motion.
 #
 class Yank extends Operator
@@ -223,5 +250,5 @@ class Mark extends OperatorWithInput
 
 module.exports = {
   Operator, OperatorWithInput, OperatorError, Delete, ToggleCase,
-  Yank, Join, Repeat, Mark
+  UpperCase, Yank, Join, Repeat, Mark
 }

--- a/lib/operators/general-operators.coffee
+++ b/lib/operators/general-operators.coffee
@@ -143,7 +143,7 @@ class ToggleCase extends Operator
     @vimState.activateCommandMode()
 
 #
-# In visual mode, it makes the selection uppercase
+# In visual mode or after `g`, it makes the selection uppercase
 #
 class UpperCase extends Operator
   constructor: (@editor, @vimState, {@selectOptions}={}) ->
@@ -165,6 +165,33 @@ class UpperCase extends Operator
             range = Range.fromPointWithDelta(point, 0, 1)
             char = @editor.getTextInBufferRange(range)
             @editor.setTextInBufferRange(range, char.toUpperCase())
+            cursor.moveRight() unless point.column >= lineLength - 1
+
+    @vimState.activateCommandMode()
+
+#
+# In visual mode or after `g`, it makes the selection lowercase
+#
+class LowerCase extends Operator
+  constructor: (@editor, @vimState, {@selectOptions}={}) ->
+    @complete = true
+
+  execute: (count=1) ->
+    if @vimState.mode is 'visual'
+      @editor.replaceSelectedText {}, (text) ->
+        text.toLowerCase()
+    else
+      @editor.transact =>
+        for cursor in @editor.getCursors()
+          point = cursor.getBufferPosition()
+          lineLength = @editor.lineTextForBufferRow(point.row).length
+          cursorCount = Math.min(count, lineLength - point.column)
+
+          _.times cursorCount, =>
+            point = cursor.getBufferPosition()
+            range = Range.fromPointWithDelta(point, 0, 1)
+            char = @editor.getTextInBufferRange(range)
+            @editor.setTextInBufferRange(range, char.toLowerCase())
             cursor.moveRight() unless point.column >= lineLength - 1
 
     @vimState.activateCommandMode()
@@ -250,5 +277,5 @@ class Mark extends OperatorWithInput
 
 module.exports = {
   Operator, OperatorWithInput, OperatorError, Delete, ToggleCase,
-  UpperCase, Yank, Join, Repeat, Mark
+  UpperCase, LowerCase, Yank, Join, Repeat, Mark
 }

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -78,6 +78,7 @@ class VimState
       'delete-to-last-character-of-line': => [new Operators.Delete(@editor, @), new Motions.MoveToLastCharacterOfLine(@editor, @)]
       'toggle-case': => new Operators.ToggleCase(@editor, @)
       'upper-case': => new Operators.UpperCase(@editor, @)
+      'lower-case': => new Operators.LowerCase(@editor, @)
       'yank': => @linewiseAliasedOperator(Operators.Yank)
       'yank-line': => [new Operators.Yank(@editor, @), new Motions.MoveToRelativeLine(@editor, @)]
       'put-before': => new Operators.Put(@editor, @, location: 'before')

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -77,6 +77,7 @@ class VimState
       'delete-left': => [new Operators.Delete(@editor, @), new Motions.MoveLeft(@editor, @)]
       'delete-to-last-character-of-line': => [new Operators.Delete(@editor, @), new Motions.MoveToLastCharacterOfLine(@editor, @)]
       'toggle-case': => new Operators.ToggleCase(@editor, @)
+      'upper-case': => new Operators.UpperCase(@editor, @)
       'yank': => @linewiseAliasedOperator(Operators.Yank)
       'yank-line': => [new Operators.Yank(@editor, @), new Motions.MoveToRelativeLine(@editor, @)]
       'put-before': => new Operators.Put(@editor, @, location: 'before')

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -79,6 +79,7 @@ class VimState
       'toggle-case': => new Operators.ToggleCase(@editor, @)
       'upper-case': => new Operators.UpperCase(@editor, @)
       'lower-case': => new Operators.LowerCase(@editor, @)
+      'toggle-case-now': => new Operators.ToggleCase(@editor, @, complete: true)
       'yank': => @linewiseAliasedOperator(Operators.Yank)
       'yank-line': => [new Operators.Yank(@editor, @), new Motions.MoveToRelativeLine(@editor, @)]
       'put-before': => new Operators.Put(@editor, @, location: 'before')

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -1296,19 +1296,30 @@ describe "Operators", ->
         keydown("~")
         expect(editor.getText()).toBe 'AbC\nXyZ'
 
+    describe "with g and motion", ->
+      it "toggles the case of text", ->
+        editor.setCursorBufferPosition([0, 0])
+        keydown("g")
+        keydown("~")
+        keydown("2")
+        keydown("l")
+        expect(editor.getText()).toBe 'Abc\nXyZ'
+
   describe 'the U keybinding', ->
     beforeEach ->
       editor.setText('aBc\nXyZ')
       editor.setCursorBufferPosition([0, 0])
 
-    it "makes one character uppercase with `g`", ->
+    it "makes text uppercase with g and motion", ->
       keydown("g")
       keydown("U", shift: true)
+      keydown("l")
       expect(editor.getText()).toBe 'ABc\nXyZ'
 
       keydown("g")
       keydown("U", shift: true)
-      expect(editor.getText()).toBe 'ABc\nXyZ'
+      keydown("e")
+      expect(editor.getText()).toBe 'ABC\nXyZ'
 
     it "makes the selected text uppercase in visual mode", ->
       keydown("V", shift: true)
@@ -1320,13 +1331,10 @@ describe "Operators", ->
       editor.setText('aBc\nXyZ')
       editor.setCursorBufferPosition([0, 0])
 
-    it "makes one character lowercase with `g`", ->
+    it "makes text lowercase with g and motion", ->
       keydown("g")
       keydown("u")
-      expect(editor.getText()).toBe 'aBc\nXyZ'
-
-      keydown("g")
-      keydown("u")
+      keydown("e")
       expect(editor.getText()).toBe 'abc\nXyZ'
 
     it "makes the selected text lowercase in visual mode", ->

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -1296,6 +1296,16 @@ describe "Operators", ->
         keydown("~")
         expect(editor.getText()).toBe 'AbC\nXyZ'
 
+  describe 'the U keybinding (in visual mode)', ->
+    beforeEach ->
+      editor.setText('aBc\nXyZ')
+      editor.setCursorBufferPosition([0, 0])
+
+    it "makes the selected text uppercase", ->
+      keydown("V", shift: true)
+      keydown("U", shift: true)
+      expect(editor.getText()).toBe 'ABC\nXyZ'
+
   describe "the i keybinding", ->
     beforeEach ->
       editor.setText('')

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -1296,15 +1296,43 @@ describe "Operators", ->
         keydown("~")
         expect(editor.getText()).toBe 'AbC\nXyZ'
 
-  describe 'the U keybinding (in visual mode)', ->
+  describe 'the U keybinding', ->
     beforeEach ->
       editor.setText('aBc\nXyZ')
       editor.setCursorBufferPosition([0, 0])
 
-    it "makes the selected text uppercase", ->
+    it "makes one character uppercase with `g`", ->
+      keydown("g")
+      keydown("U", shift: true)
+      expect(editor.getText()).toBe 'ABc\nXyZ'
+
+      keydown("g")
+      keydown("U", shift: true)
+      expect(editor.getText()).toBe 'ABc\nXyZ'
+
+    it "makes the selected text uppercase in visual mode", ->
       keydown("V", shift: true)
       keydown("U", shift: true)
       expect(editor.getText()).toBe 'ABC\nXyZ'
+
+  describe 'the u keybinding', ->
+    beforeEach ->
+      editor.setText('aBc\nXyZ')
+      editor.setCursorBufferPosition([0, 0])
+
+    it "makes one character lowercase with `g`", ->
+      keydown("g")
+      keydown("u")
+      expect(editor.getText()).toBe 'aBc\nXyZ'
+
+      keydown("g")
+      keydown("u")
+      expect(editor.getText()).toBe 'abc\nXyZ'
+
+    it "makes the selected text lowercase in visual mode", ->
+      keydown("V", shift: true)
+      keydown("u")
+      expect(editor.getText()).toBe 'abc\nXyZ'
 
   describe "the i keybinding", ->
     beforeEach ->


### PR DESCRIPTION
The code is adapted from `~` for toggle case. 
I know there is `cmd-K cmd-U` to uppercase in Atom, but it doesn't end the visual mode as VIM would.