### PR TITLE
:fix: repeating insert operations

### DIFF
--- a/lib/operators/input.coffee
+++ b/lib/operators/input.coffee
@@ -24,6 +24,8 @@ class Insert extends Operator
           @typedText,
           normalizeLineEndings: true
         )
+        cursor = @editor.getLastCursor()
+        cursor.moveLeft() unless cursor.isAtBeginningOfLine()
     else
       @vimState.activateInsertMode()
       @typingCompleted = true
@@ -33,6 +35,17 @@ class Insert extends Operator
 class InsertAfter extends Insert
   execute: ->
     @editor.moveRight() unless @editor.getLastCursor().isAtEndOfLine()
+    super
+
+class InsertAfterEndOfLine extends Insert
+  execute: ->
+    @editor.moveToEndOfLine()
+    super
+
+class InsertAtBeginningOfLine extends Insert
+  execute: ->
+    @editor.moveToBeginningOfLine()
+    @editor.moveToFirstCharacterOfLine()
     super
 
 class InsertAboveWithNewline extends Insert
@@ -165,6 +178,8 @@ class TransactionBundler
 module.exports = {
   Insert,
   InsertAfter,
+  InsertAfterEndOfLine,
+  InsertAtBeginningOfLine,
   InsertAboveWithNewline,
   InsertBelowWithNewline,
   Change,

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -66,8 +66,8 @@ class VimState
       'substitute': => new Operators.Substitute(@editor, @)
       'substitute-line': => new Operators.SubstituteLine(@editor, @)
       'insert-after': => new Operators.InsertAfter(@editor, @)
-      'insert-after-end-of-line': => [new Motions.MoveToLastCharacterOfLine(@editor, @), new Operators.InsertAfter(@editor, @)]
-      'insert-at-beginning-of-line': => [new Motions.MoveToFirstCharacterOfLine(@editor, @), new Operators.Insert(@editor, @)]
+      'insert-after-end-of-line': => new Operators.InsertAfterEndOfLine(@editor, @)
+      'insert-at-beginning-of-line': => new Operators.InsertAtBeginningOfLine(@editor, @)
       'insert-above-with-newline': => new Operators.InsertAboveWithNewline(@editor, @)
       'insert-below-with-newline': => new Operators.InsertBelowWithNewline(@editor, @)
       'delete': => @linewiseAliasedOperator(Operators.Delete)

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -993,6 +993,18 @@ describe "Operators", ->
         expect(editorElement.classList.contains('insert-mode')).toBe(true)
         expect(editor.getCursorScreenPosition()).toEqual [0, 2]
 
+      it "repeats always as insert at the end of the line", ->
+        editor.setCursorScreenPosition([0,0])
+        keydown('A', shift: true)
+        editor.insertText("abc")
+        keydown 'escape'
+        editor.setCursorScreenPosition([1,0])
+        keydown '.'
+
+        expect(editor.getText()).toBe "11abc\n22abc\n"
+        expect(editorElement.classList.contains('insert-mode')).toBe(false)
+        expect(editor.getCursorScreenPosition()).toEqual [1, 4]
+
   describe "the I keybinding", ->
     beforeEach ->
       editor.getBuffer().setText("11\n  22\n")
@@ -1011,6 +1023,19 @@ describe "Operators", ->
 
         expect(editorElement.classList.contains('insert-mode')).toBe(true)
         expect(editor.getCursorScreenPosition()).toEqual [1, 2]
+
+      it "repeats always as insert at the first character of the line", ->
+        editor.setCursorScreenPosition([0,2])
+        keydown('I', shift: true)
+        editor.insertText("abc")
+        keydown 'escape'
+        expect(editor.getCursorScreenPosition()).toEqual [0, 2]
+        editor.setCursorScreenPosition([1,4])
+        keydown '.'
+
+        expect(editor.getText()).toBe "abc11\n  abc22\n"
+        expect(editorElement.classList.contains('insert-mode')).toBe(false)
+        expect(editor.getCursorScreenPosition()).toEqual [1, 4]
 
   describe "the J keybinding", ->
     beforeEach ->
@@ -1319,7 +1344,9 @@ describe "Operators", ->
       editor.insertText("abc")
       keydown 'escape'
       keydown '.'
-      editor.insertText("ababcc")
+      expect(editor.getText()).toBe "ababcc"
+      keydown '.'
+      expect(editor.getText()).toBe "abababccc"
 
   describe 'the a keybinding', ->
     beforeEach ->
@@ -1339,5 +1366,7 @@ describe "Operators", ->
       editor.insertText("abc")
       keydown 'escape'
       expect(editor.getText()).toBe "abc"
+      expect(editor.getCursorScreenPosition()).toEqual [0, 2]
       keydown '.'
       expect(editor.getText()).toBe "abcabc"
+      expect(editor.getCursorScreenPosition()).toEqual [0, 5]


### PR DESCRIPTION
An `I` or `A` insert operation should be repeated as such, rather than
as a simple `i` or `a` operation.
Fixing this led me to find a bug: repeated insert didn’t position the
cursor correctly at the last inserted character (not after it), so even
repeated `a` or `i` wouldn’t work right; this is fixed too.

Fixes #538 .