### PR TITLE
vim-mode should dispose all its subscriptions

### DIFF
--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -27,7 +27,7 @@ class VimState
     @history = []
     @marks = {}
 
-    @editor.onDidChangeSelectionRange =>
+    @subscriptions.add @editor.onDidChangeSelectionRange =>
       if _.all(@editor.getSelections(), (selection) -> selection.isEmpty())
         @activateCommandMode() if @mode is 'visual'
       else


### PR DESCRIPTION
If I understand it correctly, this patch should be appropriate. If not, at least I'll improve my understanding. 8-)