### PR TITLE
add replace mode

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -3,6 +3,9 @@
 * There are only currently two modes, normal mode and insert mode.
 * Motions have repeat support, `d3w` will delete three words.
 * Insert mode can be entered using `i`, `I`, `a`, `A`, `o`, or `O`.
+* Replace mode can be entered using `R`
+  * Limitations:
+    * Repeating with `.` may get a bit confused by multiple cursors or when more than one line was typed
 * Registers are a work in progress
   * What Exists:
     * `a-z` - Named registers

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -5,7 +5,7 @@
 * Insert mode can be entered using `i`, `I`, `a`, `A`, `o`, or `O`.
 * Replace mode can be entered using `R`
   * Limitations:
-    * Repeating with `.` may get a bit confused by multiple cursors or when more than one line was typed
+    * If repeating with `.` gets a bit confused (e.g. by multiple cursors or when more than one line was typed), please report it with steps to reproduce if you can.
 * Registers are a work in progress
   * What Exists:
     * `a-z` - Named registers

--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -72,6 +72,9 @@
   'ctrl-r _': 'vim-mode:insert-mode-put'
   'ctrl-r "': 'vim-mode:insert-mode-put'
 
+'atom-text-editor.vim-mode.replace-mode':
+  'backspace': 'vim-mode:replace-mode-backspace'
+
 'atom-text-editor.vim-mode:not(.insert-mode)':
   'h': 'vim-mode:move-left'
   'left': 'vim-mode:move-left'
@@ -205,6 +208,7 @@
 
 'atom-text-editor.vim-mode.normal-mode':
   'i': 'vim-mode:activate-insert-mode'
+  'R': 'vim-mode:activate-replace-mode'
   'v': 'vim-mode:activate-characterwise-visual-mode'
   'V': 'vim-mode:activate-linewise-visual-mode'
   'ctrl-v': 'vim-mode:activate-blockwise-visual-mode'

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -19,6 +19,7 @@ class VimState
   mode: null
   submode: null
   destroyed: false
+  replaceModeListener: null
 
   constructor: (@editorElement, @statusBarManager, @globalVimState) ->
     @emitter = new Emitter
@@ -70,10 +71,12 @@ class VimState
       'repeat-prefix': (e) => @repeatPrefix(e)
       'reverse-selections': (e) => @reverseSelections(e)
       'undo': (e) => @undo(e)
+      'replace-mode-backspace': => @replaceModeUndo()
       'insert-mode-put': (e) => @insertRegister(@registerName(e))
 
     @registerOperationCommands
       'activate-insert-mode': => new Operators.Insert(@editor, this)
+      'activate-replace-mode': => new Operators.ReplaceMode(@editor, this)
       'substitute': => new Operators.Substitute(@editor, this)
       'substitute-line': => new Operators.SubstituteLine(@editor, this)
       'insert-after': => new Operators.InsertAfter(@editor, this)
@@ -404,13 +407,40 @@ class VimState
   # Private: Used to enable insert mode.
   #
   # Returns nothing.
-  activateInsertMode: ->
+  activateInsertMode: (subtype = null) ->
     @mode = 'insert'
     @editorElement.component.setInputEnabled(true)
     @setInsertionCheckpoint()
-    @submode = null
+    @submode = subtype
     @changeModeClass('insert-mode')
     @updateStatusBar()
+
+  activateReplaceMode: ->
+    @activateInsertMode('replace')
+    @replaceModeCheckpoint = null
+    @replaceModeCounter = 0
+    @editorElement.classList.add('replace-mode')
+    @subscriptions.add @replaceModeListener = @editor.onWillInsertText @replaceModeInsertHandler
+    @subscriptions.add @replaceModeUndoListener = @editor.onDidInsertText @replaceModeUndoHandler
+
+  replaceModeInsertHandler: (event) =>
+    chars = event.text?.split('') or []
+    selections = @editor.getSelections()
+    @replaceModeCheckpoint = @editor.createCheckpoint()
+    for char in chars
+      continue if char is '\n'
+      for selection in selections
+        # Delete next character
+        selection.delete() unless selection.cursor.isAtEndOfLine()
+
+  replaceModeUndoHandler: (event) =>
+    @editor.groupChangesSinceCheckpoint(@replaceModeCheckpoint) if @replaceModeCheckpoint?
+    @replaceModeCounter++
+
+  replaceModeUndo: ->
+    if @replaceModeCounter > 0
+      @editor.undo()
+      @replaceModeCounter--
 
   setInsertionCheckpoint: ->
     @insertionCheckpoint = @editor.createCheckpoint() unless @insertionCheckpoint?
@@ -418,6 +448,7 @@ class VimState
   deactivateInsertMode: ->
     return unless @mode in [null, 'insert']
     @editorElement.component.setInputEnabled(false)
+    @editorElement.classList.remove('replace-mode')
     @editor.groupChangesSinceCheckpoint(@insertionCheckpoint)
     changes = getChangesSinceCheckpoint(@editor.buffer, @insertionCheckpoint)
     item = @inputOperator(@history[0])
@@ -426,6 +457,13 @@ class VimState
       item.confirmChanges(changes)
     for cursor in @editor.getCursors()
       cursor.moveLeft() unless cursor.isAtBeginningOfLine()
+    if @replaceModeListener?
+      @replaceModeListener.dispose()
+      @subscriptions.remove @replaceModeListener
+      @replaceModeListener = null
+      @replaceModeUndoListener.dispose()
+      @subscriptions.remove @replaceModeUndoListener
+      @replaceModeUndoListener = null
 
   deactivateVisualMode: ->
     return unless @mode is 'visual'

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -1773,3 +1773,98 @@ describe "Operators", ->
         keydown('x', ctrl: true)
         expect(editor.getCursorBufferPositions()).toEqual [[0, 2], [1, 3], [2, 5], [3, 3], [4, 0]]
         expect(editor.getText()).toBe '122\nab44\ncd -68ef\nab-4\na-bcdef'
+
+  describe 'the R keybinding', ->
+    beforeEach ->
+      editor.setText('12345\n67890')
+      editor.setCursorBufferPosition([0, 2])
+
+    it "enters replace mode and replaces characters", ->
+      keydown "R", shift: true
+      expect(editorElement.classList.contains('insert-mode')).toBe true
+      expect(editorElement.classList.contains('replace-mode')).toBe true
+
+      editor.insertText "ab"
+      keydown 'escape'
+
+      expect(editor.getText()).toBe "12ab5\n67890"
+      expect(editor.getCursorScreenPosition()).toEqual [0, 3]
+      expect(editorElement.classList.contains('insert-mode')).toBe false
+      expect(editorElement.classList.contains('replace-mode')).toBe false
+      expect(editorElement.classList.contains('normal-mode')).toBe true
+
+    it "continues beyond end of line as insert", ->
+      keydown "R", shift: true
+      expect(editorElement.classList.contains('insert-mode')).toBe true
+      expect(editorElement.classList.contains('replace-mode')).toBe true
+
+      editor.insertText "abcde"
+      keydown 'escape'
+
+      expect(editor.getText()).toBe "12abcde\n67890"
+
+    it "treats backspace as undo", ->
+      editor.insertText "foo"
+      keydown "R", shift: true
+
+      editor.insertText "a"
+      editor.insertText "b"
+      expect(editor.getText()).toBe "12fooab5\n67890"
+
+      keydown 'backspace', raw: true
+      expect(editor.getText()).toBe "12fooa45\n67890"
+
+      editor.insertText "c"
+
+      expect(editor.getText()).toBe "12fooac5\n67890"
+
+      keydown 'backspace', raw: true
+      keydown 'backspace', raw: true
+
+      expect(editor.getText()).toBe "12foo345\n67890"
+
+      keydown 'backspace', raw: true
+      expect(editor.getText()).toBe "12foo345\n67890"
+
+    it "can be repeated", ->
+      keydown "R", shift: true
+      editor.insertText "ab"
+      keydown 'escape'
+      editor.setCursorBufferPosition([1, 2])
+      keydown '.'
+      expect(editor.getText()).toBe "12ab5\n67ab0"
+      expect(editor.getCursorScreenPosition()).toEqual [1, 3]
+
+      editor.setCursorBufferPosition([0, 4])
+      keydown '.'
+      expect(editor.getText()).toBe "12abab\n67ab0"
+      expect(editor.getCursorScreenPosition()).toEqual [0, 5]
+
+    it "can be interrupted by arrow keys and behave as insert for repeat", ->
+      # FIXME don't know how to test this (also, depends on PR #568)
+
+    it "repeats correctly when backspace was used in the text", ->
+      keydown "R", shift: true
+      editor.insertText "a"
+      keydown 'backspace', raw: true
+      editor.insertText "b"
+      keydown 'escape'
+      editor.setCursorBufferPosition([1, 2])
+      keydown '.'
+      expect(editor.getText()).toBe "12b45\n67b90"
+      expect(editor.getCursorScreenPosition()).toEqual [1, 2]
+
+      editor.setCursorBufferPosition([0, 4])
+      keydown '.'
+      expect(editor.getText()).toBe "12b4b\n67b90"
+      expect(editor.getCursorScreenPosition()).toEqual [0, 4]
+
+    it "doesn't replace a character if newline is entered", ->
+      keydown "R", shift: true
+      expect(editorElement.classList.contains('insert-mode')).toBe true
+      expect(editorElement.classList.contains('replace-mode')).toBe true
+
+      editor.insertText "\n"
+      keydown 'escape'
+
+      expect(editor.getText()).toBe "12\n345\n67890"

--- a/spec/vim-state-spec.coffee
+++ b/spec/vim-state-spec.coffee
@@ -143,6 +143,14 @@ describe "VimState", ->
         expect(editorElement.classList.contains('insert-mode')).toBe(true)
         expect(editorElement.classList.contains('normal-mode')).toBe(false)
 
+    describe "the R keybinding", ->
+      beforeEach -> keydown('R', shift: true)
+
+      it "puts the editor into replace mode", ->
+        expect(editorElement.classList.contains('insert-mode')).toBe(true)
+        expect(editorElement.classList.contains('replace-mode')).toBe(true)
+        expect(editorElement.classList.contains('normal-mode')).toBe(false)
+
     describe "with content", ->
       beforeEach -> editor.setText("012345\n\nabcdef")
 
@@ -212,6 +220,56 @@ describe "VimState", ->
 
       expect(editorElement.classList.contains('normal-mode')).toBe(true)
       expect(editorElement.classList.contains('insert-mode')).toBe(false)
+      expect(editorElement.classList.contains('visual-mode')).toBe(false)
+
+  describe "replace-mode", ->
+    describe "with content", ->
+      beforeEach -> editor.setText("012345\n\nabcdef")
+
+      describe "when cursor is in the middle of the line", ->
+        beforeEach ->
+          editor.setCursorScreenPosition([0, 3])
+          keydown('R', shift: true)
+
+        it "moves the cursor to the left when exiting replace mode", ->
+          keydown('escape')
+          expect(editor.getCursorScreenPosition()).toEqual [0, 2]
+
+      describe "when cursor is at the beginning of line", ->
+        beforeEach ->
+          editor.setCursorScreenPosition([1, 0])
+          keydown('R', shift: true)
+
+        it "leaves the cursor at the beginning of line", ->
+          keydown('escape')
+          expect(editor.getCursorScreenPosition()).toEqual [1, 0]
+
+      describe "on a line with content", ->
+        beforeEach ->
+          keydown('R', shift: true)
+          editor.setCursorScreenPosition([0, 6])
+
+        it "allows the cursor to be placed on the \n character", ->
+          expect(editor.getCursorScreenPosition()).toEqual [0, 6]
+
+    it "puts the editor into normal mode when <escape> is pressed", ->
+      keydown('R', shift: true)
+      keydown('escape')
+
+      expect(editorElement.classList.contains('normal-mode')).toBe(true)
+      expect(editorElement.classList.contains('insert-mode')).toBe(false)
+      expect(editorElement.classList.contains('replace-mode')).toBe(false)
+      expect(editorElement.classList.contains('visual-mode')).toBe(false)
+
+    it "puts the editor into normal mode when <ctrl-c> is pressed", ->
+      keydown('R', shift: true)
+      helpers.mockPlatform(editorElement, 'platform-darwin')
+      keydown('c', ctrl: true)
+      helpers.unmockPlatform(editorElement)
+
+      expect(editorElement.classList.contains('normal-mode')).toBe(true)
+      expect(editorElement.classList.contains('insert-mode')).toBe(false)
+      expect(editorElement.classList.contains('replace-mode')).toBe(false)
       expect(editorElement.classList.contains('visual-mode')).toBe(false)
 
   describe "visual-mode", ->

--- a/styles/vim-mode.less
+++ b/styles/vim-mode.less
@@ -20,6 +20,14 @@
   opacity: 0.5;
 }
 
+.underline-cursor(@visibility: visible) {
+  border: none;
+  border-bottom: .3em solid @syntax-cursor-color;
+  background: none;
+  visibility: @visibility;
+  opacity: 0.5;
+}
+
 atom-text-editor.vim-mode.normal-mode,
 atom-text-editor.vim-mode.operator-pending-mode,
 atom-text-editor.vim-mode.visual-mode,
@@ -27,7 +35,7 @@ atom-text-editor.vim-mode.visual-mode,
   &::shadow, // shadow-DOM enabled
   &           // shadow-DOM disabled
   {
-    .cursor, .cursor.blink-off {
+    .cursor {
       .block-cursor(hidden);
     }
   }
@@ -40,7 +48,7 @@ atom-text-editor.vim-mode.visual-mode.is-focused
   &::shadow, // shadow-DOM enabled
   &           // shadow-DOM disabled
   {
-    .cursor, .cursor.blink-off {
+    .cursor {
       .block-cursor;
     }
   }
@@ -53,6 +61,32 @@ atom-text-editor.vim-mode.visual-mode
   {
     .cursor.hidden-cursor {
       display: block;
+    }
+  }
+}
+
+atom-text-editor.vim-mode.replace-mode
+{
+  &::shadow, // shadow-DOM enabled
+  &           // shadow-DOM disabled
+  {
+    .cursor {
+      .underline-cursor(hidden);
+    }
+  }
+}
+
+atom-text-editor.vim-mode.replace-mode.is-focused
+{
+  &::shadow, // shadow-DOM enabled
+  &           // shadow-DOM disabled
+  {
+    .cursor {
+      .underline-cursor;
+    }
+
+    .cursors.blink-off .cursor {
+      .underline-cursor(hidden);
     }
   }
 }


### PR DESCRIPTION
This addresses #562; also it partly addresses #564.

I got the inspiration for this implementation from @brunetton's `atom-overtype-mode` package.

*(edited)*
**Features:**
 * `backspace` acts as undo
 * block cursor and status bar indication of replace mode

**Limitations:**
 * `.` with multiple cursors may eat a character for one of those cursors, but I’ve no idea why