### PR TITLE
Ensure delete-word tries to stop at the end of the line

### DIFF
--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -201,7 +201,18 @@ class MoveToNextWord extends Motion
   wordRegex: null
   operatesInclusively: false
 
+  wordRegExp: (cursor, {includeNonWordCharacters}={}) ->
+    includeNonWordCharacters ?= true
+    nonWordCharacters = atom.config.get('editor.nonWordCharacters', scope: cursor.getScopeDescriptor())
+    segments = ["^[\t ]*$"]
+    segments.push("[^\\s#{_.escapeRegExp(nonWordCharacters)}]+")
+    segments.push("$")
+    if includeNonWordCharacters
+      segments.push("[#{_.escapeRegExp(nonWordCharacters)}]+")
+    new RegExp(segments.join("|"), "g")
+
   moveCursor: (cursor, count=1, options) ->
+    @wordRegex = @wordRegExp(cursor)
     _.times count, =>
       current = cursor.getBufferPosition()
 

--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -212,7 +212,7 @@ class MoveToNextWord extends Motion
     new RegExp(segments.join("|"), "g")
 
   moveCursor: (cursor, count=1, options) ->
-    @wordRegex = @wordRegExp(cursor)
+    @wordRegex = @wordRegExp(cursor) if options?.allowEOL
     _.times count, =>
       current = cursor.getBufferPosition()
 

--- a/lib/operators/general-operators.coffee
+++ b/lib/operators/general-operators.coffee
@@ -84,6 +84,7 @@ class Delete extends Operator
     @complete = false
     @selectOptions ?= {}
     @selectOptions.requireEOL ?= true
+    @selectOptions.allowEOL ?= true
     @register = settings.defaultRegister()
 
   # Public: Deletes the text selected by the given motion.

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -240,9 +240,10 @@ describe "Operators", ->
         keydown('w')
 
         # Incompatibility with VIM. In vim, `w` behaves differently as an
-        # operator than as a motion; it stops at the end of a line.expect(editor.getText()).toBe "abcd abc"
-        expect(editor.getText()).toBe "abcd abc"
-        expect(editor.getCursorScreenPosition()).toEqual [0, 5]
+        # operator than as a motion; it stops at the end of a line
+        # and removes the preceding space: `expect(editor.getText()).toBe "abcd\nabc"`
+        expect(editor.getText()).toBe "abcd \nabc"
+        expect(editor.getCursorScreenPosition()).toEqual [0, 4]
 
         expect(editorElement.classList.contains('operator-pending-mode')).toBe(false)
         expect(editorElement.classList.contains('command-mode')).toBe(true)


### PR DESCRIPTION
Fixes #550.
- I had to add a different word regex to add `$`.  I'd rather have an option built into the Cursor class instead of adding it to this package.  I can submit that PR if that is a better approach.
- I wanted to set the `allowEOL` option from _vim-state.coffee_, but couldn't figure out how to do that.  Right now, the custom word regex is set for all delete operators.
- In vim, I noticed that `dw` also deletes the preceeding space, which this PR doesn't fix.
