### PR TITLE
fix cursor position after operator

### DIFF
--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -1364,6 +1364,13 @@ describe "Operators", ->
       keydown("e")
       expect(editor.getText()).toBe 'ABC\nXyZ'
 
+      editor.setCursorBufferPosition([1, 0])
+      keydown("g")
+      keydown("U", shift: true)
+      keydown("$")
+      expect(editor.getText()).toBe 'ABC\nXYZ'
+      expect(editor.getCursorScreenPosition()).toEqual [1, 2]
+
     it "makes the selected text uppercase in visual mode", ->
       keydown("V", shift: true)
       keydown("U", shift: true)
@@ -1377,8 +1384,9 @@ describe "Operators", ->
     it "makes text lowercase with g and motion", ->
       keydown("g")
       keydown("u")
-      keydown("e")
+      keydown("$")
       expect(editor.getText()).toBe 'abc\nXyZ'
+      expect(editor.getCursorScreenPosition()).toEqual [0, 2]
 
     it "makes the selected text lowercase in visual mode", ->
       keydown("V", shift: true)


### PR DESCRIPTION
`gU$` and such could put the cursor at the end of the line, not the last character as expected in vim mode