### PR TITLE
fix: yank should not scroll

### DIFF
--- a/lib/operators/general-operators.coffee
+++ b/lib/operators/general-operators.coffee
@@ -178,13 +178,20 @@ class Yank extends Operator
   #
   # Returns nothing.
   execute: (count) ->
+    oldTop = @editor.getScrollTop()
+    oldLeft = @editor.getScrollLeft()
+    oldLastCursorPosition = @editor.getCursorBufferPosition()
+
     originalPositions = @editor.getCursorBufferPositions()
     if _.contains(@motion.select(count), true)
       text = @editor.getSelectedText()
       startPositions = _.pluck(@editor.getSelectedBufferRanges(), "start")
       newPositions = for originalPosition, i in originalPositions
-        if startPositions[i] and (@vimState.mode is 'visual' or not @motion.isLinewise?())
-          Point.min(startPositions[i], originalPositions[i])
+        if startPositions[i]
+          position = Point.min(startPositions[i], originalPositions[i])
+          if @vimState.mode isnt 'visual' and @motion.isLinewise?()
+            position = new Point(position.row, originalPositions[i].column)
+          position
         else
           originalPosition
     else
@@ -194,6 +201,11 @@ class Yank extends Operator
     @setTextRegister(@register, text)
 
     @editor.setSelectedBufferRanges(newPositions.map (p) -> new Range(p, p))
+
+    if oldLastCursorPosition.isEqual(@editor.getCursorBufferPosition())
+      @editor.setScrollLeft(oldLeft)
+      @editor.setScrollTop(oldTop)
+
     @vimState.activateNormalMode()
 
 #

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -100,7 +100,6 @@ describe "Operators", ->
           keydown('u')
           expect(editor.getText()).toBe "abc\n012345\n\nxyz"
 
-
       describe "with vim-mode.wrapLeftRightMotion", ->
         beforeEach ->
           editor.setText("abc\n012345\n\nxyz")
@@ -160,7 +159,6 @@ describe "Operators", ->
           expect(editor.getCursorScreenPosition()).toEqual [0, 1]
           expect(vimState.getRegister('"').text).toBe '0123\n\nx'
 
-
     describe "on an empty line", ->
       beforeEach ->
         editor.setText("abc\n012345\n\nxyz")
@@ -177,7 +175,6 @@ describe "Operators", ->
         keydown('x')
         expect(editor.getText()).toBe "abc\n012345\nxyz"
         expect(editor.getCursorScreenPosition()).toEqual [2, 0]
-
 
   describe "the X keybinding", ->
     describe "on a line with content", ->
@@ -206,7 +203,6 @@ describe "Operators", ->
         expect(editor.getText()).toBe 'ab2345'
         expect(editor.getCursorScreenPosition()).toEqual [0, 2]
         expect(vimState.getRegister('"').text).toBe '\n'
-
 
     describe "on an empty line", ->
       beforeEach ->
@@ -939,7 +935,7 @@ describe "Operators", ->
       describe "yanking many lines forward", ->
         it "does not scroll the window", ->
           editor.setCursorBufferPosition [40, 1]
-          top40 = editor.getScrollTop()
+          previousScrollTop = editor.getScrollTop()
 
           # yank many lines
           keydown('y')
@@ -948,14 +944,14 @@ describe "Operators", ->
           keydown('0')
           keydown('G', shift: true)
 
-          expect(editor.getScrollTop()).toEqual(top40)
+          expect(editor.getScrollTop()).toEqual(previousScrollTop)
           expect(editor.getCursorBufferPosition()).toEqual [40, 1]
           expect(vimState.getRegister('"').text.split('\n').length).toBe 121
 
       describe "yanking many lines backwards", ->
         it "scrolls the window", ->
           editor.setCursorBufferPosition [140, 1]
-          top140 = editor.getScrollTop()
+          previousScrollTop = editor.getScrollTop()
 
           # yank many lines
           keydown('y')
@@ -963,10 +959,9 @@ describe "Operators", ->
           keydown('0')
           keydown('G', shift: true)
 
-          expect(editor.getScrollTop()).toNotEqual top140
+          expect(editor.getScrollTop()).toNotEqual previousScrollTop
           expect(editor.getCursorBufferPosition()).toEqual [59, 1]
           expect(vimState.getRegister('"').text.split('\n').length).toBe 83
-
 
   describe "the yy keybinding", ->
     describe "on a single line file", ->

--- a/spec/scroll-spec.coffee
+++ b/spec/scroll-spec.coffee
@@ -18,6 +18,39 @@ describe "Scrolling", ->
     options.element ?= editorElement
     helpers.keydown(key, options)
 
+  describe "normal movements (sanity check for scrolling)", ->
+    beforeEach ->
+      editor.setHeight(400)
+      editor.setLineHeightInPixels(10)
+      editor.setDefaultCharWidth(10)
+      text = ""
+      for i in [1..200]
+        text += "#{i}\n"
+      editor.setText(text)
+
+    describe "the G keybinding", ->
+      it "scrolls the window", ->
+        editor.setCursorBufferPosition [0, 0]
+        top0 = editor.getScrollTop()
+
+        editor.setCursorBufferPosition [100, 0]
+        top100 = editor.getScrollTop()
+        expect(top100).toBeGreaterThan(top0)
+
+        editor.setCursorBufferPosition [101, 0]
+        top101 = editor.getScrollTop()
+        expect(top101-top100).toEqual(10)
+
+        editor.setCursorBufferPosition [161, 0]
+        top161 = editor.getScrollTop()
+        expect(top161-top100).toEqual(610)
+
+        editor.setCursorBufferPosition [0, 0]
+        expect(editor.getScrollTop()).toNotBe top101
+        editor.setCursorBufferPosition [101, 0]
+        expect(editor.getScrollTop()).toBe top101
+
+
   describe "scrolling keybindings", ->
     beforeEach ->
       editor.setText("1\n2\n3\n4\n5\n6\n7\n8\n9\n10")

--- a/spec/scroll-spec.coffee
+++ b/spec/scroll-spec.coffee
@@ -18,39 +18,6 @@ describe "Scrolling", ->
     options.element ?= editorElement
     helpers.keydown(key, options)
 
-  describe "normal movements (sanity check for scrolling)", ->
-    beforeEach ->
-      editor.setHeight(400)
-      editor.setLineHeightInPixels(10)
-      editor.setDefaultCharWidth(10)
-      text = ""
-      for i in [1..200]
-        text += "#{i}\n"
-      editor.setText(text)
-
-    describe "the G keybinding", ->
-      it "scrolls the window", ->
-        editor.setCursorBufferPosition [0, 0]
-        top0 = editor.getScrollTop()
-
-        editor.setCursorBufferPosition [100, 0]
-        top100 = editor.getScrollTop()
-        expect(top100).toBeGreaterThan(top0)
-
-        editor.setCursorBufferPosition [101, 0]
-        top101 = editor.getScrollTop()
-        expect(top101-top100).toEqual(10)
-
-        editor.setCursorBufferPosition [161, 0]
-        top161 = editor.getScrollTop()
-        expect(top161-top100).toEqual(610)
-
-        editor.setCursorBufferPosition [0, 0]
-        expect(editor.getScrollTop()).toNotBe top101
-        editor.setCursorBufferPosition [101, 0]
-        expect(editor.getScrollTop()).toBe top101
-
-
   describe "scrolling keybindings", ->
     beforeEach ->
       editor.setText("1\n2\n3\n4\n5\n6\n7\n8\n9\n10")


### PR DESCRIPTION
Yank currently shows the target of the motion, for example on a line that's longer than the screen, `y$` will scroll so that the end of the line is visible, and `yn` will scroll to the next search match, even if that means that the cursor goes off-screen. This PR fixes that.
I don't know how to spec it, similarly to #558 .