### PR TITLE
Fix: Prevent ":not([mini])" commands from being fired in search-mode

### DIFF
--- a/lib/view-models/vim-command-mode-input-view.coffee
+++ b/lib/view-models/vim-command-mode-input-view.coffee
@@ -16,6 +16,7 @@ class VimCommandModeInputView extends View
     @editorElement = document.createElement "atom-text-editor"
     @editorElement.classList.add('editor')
     @editorElement.getModel().setMini(true)
+    @editorElement.setAttribute 'mini', ''
     @editorContainer.append(@editorElement)
 
     @singleChar = opts.singleChar


### PR DESCRIPTION
Since pr #582 commands with `:not([mini])` filter in command definition get fired in search-mode editor in case of a missing `mini` attribute in the `atom-text-editor` element.

The way how the editor-view was created in the bottom panel has changed from:

```javascript
new TextEditorView(mini: true)
```
to:

```javascript
@editorElement = document.createElement "atom-text-editor"
@editorElement.classList.add('editor')
@editorElement.getModel().setMini(true)
```
The `setMini` setter only sets the mini attribute in the model not in the editor-view.