### PR TITLE
`%` should not affect `n`

### DIFF
--- a/lib/motions/search-motion.coffee
+++ b/lib/motions/search-motion.coffee
@@ -9,9 +9,9 @@ class SearchBase extends MotionWithInput
   operatesInclusively: false
   @currentSearch: null
 
-  constructor: (@editor, @vimState) ->
+  constructor: (@editor, @vimState, options = {}) ->
     super(@editor, @vimState)
-    Search.currentSearch = @
+    Search.currentSearch = @ unless options?.notCurrent
     @reverse = @initiallyReversed = false
 
   repeat: (opts = {}) =>
@@ -75,8 +75,6 @@ class Search extends SearchBase
   constructor: (@editor, @vimState) ->
     super(@editor, @vimState)
     @viewModel = new SearchViewModel(@)
-    Search.currentSearch = @
-    @reverse = @initiallyReversed = false
 
   compose: (input) ->
     super(input)
@@ -87,8 +85,6 @@ class SearchCurrentWord extends SearchBase
 
   constructor: (@editor, @vimState) ->
     super(@editor, @vimState)
-    Search.currentSearch = @
-    @reverse = @initiallyReversed = false
 
     # FIXME: This must depend on the current language
     defaultIsKeyword = "[@a-zA-Z0-9_\-]+"
@@ -141,9 +137,7 @@ class BracketMatchingMotion extends SearchBase
   @keywordRegex: null
 
   constructor: (@editor, @vimState) ->
-    super(@editor, @vimState)
-    Search.currentSearch = @
-    @reverse = @initiallyReversed = false
+    super(@editor, @vimState, notCurrent: true)
 
   isComplete: -> true
 

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -1691,3 +1691,12 @@ describe "Motions", ->
       editor.setCursorScreenPosition([0, 0])
       keydown("%")
       expect(editor.getCursorScreenPosition()).toEqual([1, 3])
+
+    it "does not affect search history", ->
+      keydown('/')
+      submitCommandModeInputText 'func'
+      expect(editor.getCursorBufferPosition()).toEqual [0, 31]
+      keydown('%')
+      expect(editor.getCursorBufferPosition()).toEqual [0, 60]
+      keydown('n')
+      expect(editor.getCursorBufferPosition()).toEqual [0, 31]


### PR DESCRIPTION
the `%` motion in VIM does not become the motion repeated with `n`;
this PR fixes this in vim-mode
Let me know if this way of adding exceptions is not the preferred one, and if so please point me to the preferred one. 8-)

this also removes some unnecessary repetition in search motion constructors