### PR TITLE
Global current search

### DIFF
--- a/lib/global-vim-state.coffee
+++ b/lib/global-vim-state.coffee
@@ -2,3 +2,4 @@ module.exports =
 class GlobalVimState
   registers: {}
   searchHistory: []
+  currentSearch: {}

--- a/lib/motions/index.coffee
+++ b/lib/motions/index.coffee
@@ -1,11 +1,12 @@
 Motions = require './general-motions'
-{Search, SearchCurrentWord, BracketMatchingMotion} = require './search-motion'
+{Search, SearchCurrentWord, BracketMatchingMotion, RepeatSearch} = require './search-motion'
 MoveToMark = require './move-to-mark-motion'
 {Find, Till} = require './find-motion'
 
 Motions.Search = Search
 Motions.SearchCurrentWord = SearchCurrentWord
 Motions.BracketMatchingMotion = BracketMatchingMotion
+Motions.RepeatSearch = RepeatSearch
 Motions.MoveToMark = MoveToMark
 Motions.Find = Find
 Motions.Till = Till

--- a/lib/motions/search-motion.coffee
+++ b/lib/motions/search-motion.coffee
@@ -75,8 +75,6 @@ class Search extends SearchBase
   constructor: (@editor, @vimState) ->
     super(@editor, @vimState)
     @viewModel = new SearchViewModel(@)
-    Search.currentSearch = @
-    @reverse = @initiallyReversed = false
 
   compose: (input) ->
     super(input)
@@ -87,8 +85,6 @@ class SearchCurrentWord extends SearchBase
 
   constructor: (@editor, @vimState) ->
     super(@editor, @vimState)
-    Search.currentSearch = @
-    @reverse = @initiallyReversed = false
 
     # FIXME: This must depend on the current language
     defaultIsKeyword = "[@a-zA-Z0-9_\-]+"
@@ -142,8 +138,6 @@ class BracketMatchingMotion extends SearchBase
 
   constructor: (@editor, @vimState) ->
     super(@editor, @vimState)
-    Search.currentSearch = @
-    @reverse = @initiallyReversed = false
 
   isComplete: -> true
 

--- a/lib/motions/search-motion.coffee
+++ b/lib/motions/search-motion.coffee
@@ -136,10 +136,6 @@ AnyBracket = new RegExp(OpenBrackets.concat(CloseBrackets).map(_.escapeRegExp).j
 
 class BracketMatchingMotion extends SearchBase
   operatesInclusively: true
-  @keywordRegex: null
-
-  constructor: (@editor, @vimState) ->
-    super(@editor, @vimState)
 
   isComplete: -> true
 

--- a/lib/view-models/search-view-model.coffee
+++ b/lib/view-models/search-view-model.coffee
@@ -10,7 +10,7 @@ class SearchViewModel extends ViewModel
     atom.commands.add(@view.editorElement, 'core:move-down', @decreaseHistorySearch)
 
   restoreHistory: (index) ->
-    @view.editorElement.getModel().setText(@history(index).value)
+    @view.editorElement.getModel().setText(@history(index))
 
   history: (index) ->
     @vimState.getSearchHistoryItem(index)
@@ -30,5 +30,5 @@ class SearchViewModel extends ViewModel
       @restoreHistory(@historyIndex)
 
   confirm: (view) =>
-    @vimState.pushSearchHistory(@)
     super(view)
+    @vimState.pushSearchHistory(@value)

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -147,8 +147,8 @@ class VimState
       'select-around-parentheses': => new TextObjects.SelectInsideBrackets(@editor, '(', ')', true)
       'register-prefix': (e) => @registerPrefix(e)
       'repeat': (e) => new Operators.Repeat(@editor, @)
-      'repeat-search': (e) => currentSearch.repeat() if (currentSearch = Motions.Search.currentSearch)?
-      'repeat-search-backwards': (e) => currentSearch.repeat(backwards: true) if (currentSearch = Motions.Search.currentSearch)?
+      'repeat-search': (e) => new Motions.RepeatSearch(@editor, @)
+      'repeat-search-backwards': (e) => new Motions.RepeatSearch(@editor, @).reversed()
       'focus-pane-view-on-left': => new Panes.FocusPaneViewOnLeft()
       'focus-pane-view-on-right': => new Panes.FocusPaneViewOnRight()
       'focus-pane-view-above': => new Panes.FocusPaneViewAbove()
@@ -356,7 +356,7 @@ class VimState
   # index - the index of the search history item
   #
   # Returns a search motion
-  getSearchHistoryItem: (index) ->
+  getSearchHistoryItem: (index = 0) ->
     @globalVimState.searchHistory[index]
 
   ##############################################################################

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -1154,13 +1154,19 @@ describe "Motions", ->
 
   describe "the * keybinding", ->
     beforeEach ->
-      editor.setText("abc\n@def\nabc\ndef\n")
+      editor.setText("abd\n@def\nabd\ndef\n")
       editor.setCursorBufferPosition([0, 0])
 
     describe "as a motion", ->
       it "moves cursor to next occurence of word under cursor", ->
         keydown("*")
         expect(editor.getCursorBufferPosition()).toEqual [2, 0]
+
+      it "repeats with the n key", ->
+        keydown("*")
+        expect(editor.getCursorBufferPosition()).toEqual [2, 0]
+        keydown("n")
+        expect(editor.getCursorBufferPosition()).toEqual [0, 0]
 
       it "doesn't move cursor unless next occurence is the exact word (no partial matches)", ->
         editor.setText("abc\ndef\nghiabc\njkl\nabcdef")
@@ -1227,6 +1233,16 @@ describe "Motions", ->
         editor.setCursorBufferPosition([2, 1])
         keydown("#")
         expect(editor.getCursorBufferPosition()).toEqual [0, 0]
+
+      it "repeats with n", ->
+        editor.setText("abc\n@def\nabc\ndef\nabc\n")
+        editor.setCursorBufferPosition([2, 1])
+        keydown("#")
+        expect(editor.getCursorBufferPosition()).toEqual [0, 0]
+        keydown("n")
+        expect(editor.getCursorBufferPosition()).toEqual [4, 0]
+        keydown("n")
+        expect(editor.getCursorBufferPosition()).toEqual [2, 0]
 
       it "doesn't move cursor unless next occurence is the exact word (no partial matches)", ->
         editor.setText("abc\ndef\nghiabc\njkl\nabcdef")
@@ -1691,3 +1707,12 @@ describe "Motions", ->
       editor.setCursorScreenPosition([0, 0])
       keydown("%")
       expect(editor.getCursorScreenPosition()).toEqual([1, 3])
+
+    it "does not affect search history", ->
+      keydown('/')
+      submitCommandModeInputText 'func'
+      expect(editor.getCursorBufferPosition()).toEqual [0, 31]
+      keydown('%')
+      expect(editor.getCursorBufferPosition()).toEqual [0, 60]
+      keydown('n')
+      expect(editor.getCursorBufferPosition()).toEqual [0, 31]


### PR DESCRIPTION
Make current search part of the global state.
Also prevents `%` from affecting `n`; and also puts the word searched for by `*` and `#` into search history.
Obsoletes #606. Fixes #190 I think.