### PR TITLE
Use g~g~, gugu and gUgU to switch casing on whole lines

### DIFF
--- a/lib/operators/general-operators.coffee
+++ b/lib/operators/general-operators.coffee
@@ -142,7 +142,7 @@ class ToggleCase extends Operator
 
     @vimState.activateCommandMode()
 
-    if @motion.isLinewise?()
+    if @motion? and @motion.isLinewise?()
       @editor.moveToPreviousWordBoundary()
       @editor.moveToFirstCharacterOfLine()
 
@@ -160,7 +160,7 @@ class UpperCase extends Operator
 
     @vimState.activateCommandMode()
 
-    if @motion.isLinewise?()
+    if @motion? and @motion.isLinewise?()
       @editor.moveToPreviousWordBoundary()
       @editor.moveToFirstCharacterOfLine()
 
@@ -178,7 +178,7 @@ class LowerCase extends Operator
 
     @vimState.activateCommandMode()
 
-    if @motion.isLinewise?()
+    if @motion and @motion.isLinewise?()
       @editor.moveToPreviousWordBoundary()
       @editor.moveToFirstCharacterOfLine()
 

--- a/lib/operators/general-operators.coffee
+++ b/lib/operators/general-operators.coffee
@@ -142,6 +142,10 @@ class ToggleCase extends Operator
 
     @vimState.activateCommandMode()
 
+    if @motion.isLinewise?()
+      @editor.moveToPreviousWordBoundary()
+      @editor.moveToFirstCharacterOfLine()
+
 #
 # In visual mode or after `g` with a motion, it makes the selection uppercase
 #
@@ -156,6 +160,10 @@ class UpperCase extends Operator
 
     @vimState.activateCommandMode()
 
+    if @motion.isLinewise?()
+      @editor.moveToPreviousWordBoundary()
+      @editor.moveToFirstCharacterOfLine()
+
 #
 # In visual mode or after `g` with a motion, it makes the selection lowercase
 #
@@ -169,6 +177,10 @@ class LowerCase extends Operator
         text.toLowerCase()
 
     @vimState.activateCommandMode()
+
+    if @motion.isLinewise?()
+      @editor.moveToPreviousWordBoundary()
+      @editor.moveToFirstCharacterOfLine()
 
 #
 # It copies everything selected by the following motion.

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -83,9 +83,9 @@ class VimState
       'delete-right': => [new Operators.Delete(@editor, @), new Motions.MoveRight(@editor, @)]
       'delete-left': => [new Operators.Delete(@editor, @), new Motions.MoveLeft(@editor, @)]
       'delete-to-last-character-of-line': => [new Operators.Delete(@editor, @), new Motions.MoveToLastCharacterOfLine(@editor, @)]
-      'toggle-case': => new Operators.ToggleCase(@editor, @)
-      'upper-case': => new Operators.UpperCase(@editor, @)
-      'lower-case': => new Operators.LowerCase(@editor, @)
+      'toggle-case': => @linewiseAliasedOperator(Operators.ToggleCase)
+      'upper-case': => @linewiseAliasedOperator(Operators.UpperCase)
+      'lower-case': => @linewiseAliasedOperator(Operators.LowerCase)
       'toggle-case-now': => new Operators.ToggleCase(@editor, @, complete: true)
       'yank': => @linewiseAliasedOperator(Operators.Yank)
       'yank-line': => [new Operators.Yank(@editor, @), new Motions.MoveToRelativeLine(@editor, @)]

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -1336,8 +1336,8 @@ describe "Operators", ->
         expect(editor.getText()).toBe 'Abc\nXyZ'
 
     describe "when followed by g~", ->
-      it "toggles the case of the whole line", ->
-        editor.setCursorBufferPosition([2, 2])
+      it "toggles the case of the whole line, and the cursor ends up on the first character of that line", ->
+        editor.setCursorBufferPosition([1, 1])
 
         keydown('g')
         keydown('~')
@@ -1345,6 +1345,7 @@ describe "Operators", ->
         keydown('~')
 
         expect(editor.getText()).toBe "aBc\nxYz"
+        expect(editor.getCursorScreenPosition()).toEqual [1, 0]
 
   describe 'the gU keybinding', ->
     beforeEach ->
@@ -1368,8 +1369,8 @@ describe "Operators", ->
       expect(editor.getText()).toBe 'ABC\nXyZ'
 
     describe "when followed by gU", ->
-      it "makes the whole line uppercase", ->
-        editor.setCursorBufferPosition([2, 2])
+      it "makes the whole line uppercase, and the cursor ends up on the first character of that line", ->
+        editor.setCursorBufferPosition([1, 1])
 
         keydown('g')
         keydown('U', shift: true)
@@ -1377,6 +1378,7 @@ describe "Operators", ->
         keydown('U', shift: true)
 
         expect(editor.getText()).toBe "aBc\nXYZ"
+        expect(editor.getCursorBufferPosition()).toEqual [1, 0]
 
   describe 'the gu keybinding', ->
     beforeEach ->
@@ -1395,8 +1397,8 @@ describe "Operators", ->
       expect(editor.getText()).toBe 'abc\nXyZ'
 
     describe "when followed by gu", ->
-      it "makes the whole line lowercase", ->
-        editor.setCursorBufferPosition([2, 2])
+      it "makes the whole line lowercase, and the cursor ends up on the first character of that line", ->
+        editor.setCursorBufferPosition([1, 1])
 
         keydown('g')
         keydown('u')
@@ -1404,6 +1406,7 @@ describe "Operators", ->
         keydown('u')
 
         expect(editor.getText()).toBe "aBc\nxyz"
+        expect(editor.getCursorScreenPosition()).toEqual [1, 0]
 
   describe "the i keybinding", ->
     beforeEach ->

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -1293,7 +1293,7 @@ describe "Operators", ->
       commandModeInputKeydown('a')
       expect(vimState.getMark('a')).toEqual [0,1]
 
-  describe 'the ~ keybinding', ->
+  describe 'the g~ keybinding', ->
     beforeEach ->
       editor.setText('aBc\nXyZ')
       editor.setCursorBufferPosition([0, 0])
@@ -1335,7 +1335,18 @@ describe "Operators", ->
         keydown("l")
         expect(editor.getText()).toBe 'Abc\nXyZ'
 
-  describe 'the U keybinding', ->
+    describe "when followed by g~", ->
+      it "toggles the case of the whole line", ->
+        editor.setCursorBufferPosition([2, 2])
+
+        keydown('g')
+        keydown('~')
+        keydown('g')
+        keydown('~')
+
+        expect(editor.getText()).toBe "aBc\nxYz"
+
+  describe 'the gU keybinding', ->
     beforeEach ->
       editor.setText('aBc\nXyZ')
       editor.setCursorBufferPosition([0, 0])
@@ -1356,7 +1367,18 @@ describe "Operators", ->
       keydown("U", shift: true)
       expect(editor.getText()).toBe 'ABC\nXyZ'
 
-  describe 'the u keybinding', ->
+    describe "when followed by gU", ->
+      it "makes the whole line uppercase", ->
+        editor.setCursorBufferPosition([2, 2])
+
+        keydown('g')
+        keydown('U', shift: true)
+        keydown('g')
+        keydown('U', shift: true)
+
+        expect(editor.getText()).toBe "aBc\nXYZ"
+
+  describe 'the gu keybinding', ->
     beforeEach ->
       editor.setText('aBc\nXyZ')
       editor.setCursorBufferPosition([0, 0])
@@ -1371,6 +1393,17 @@ describe "Operators", ->
       keydown("V", shift: true)
       keydown("u")
       expect(editor.getText()).toBe 'abc\nXyZ'
+
+    describe "when followed by gu", ->
+      it "makes the whole line lowercase", ->
+        editor.setCursorBufferPosition([2, 2])
+
+        keydown('g')
+        keydown('u')
+        keydown('g')
+        keydown('u')
+
+        expect(editor.getText()).toBe "aBc\nxyz"
 
   describe "the i keybinding", ->
     beforeEach ->


### PR DESCRIPTION
I made it possible to use the g~g~, gugu and gUgU commands to change casing on a whole line.

Using linewiseAliasedOperator made the cursor jump to the line below when done, so I made TextEditor move the cursor to the first character of the correct line, the way it works in Vim. There should probably be a better way to fix this though.

In Vim it's also possible also use gUU, guu and g~~, which is less verbose. I'm not really sure how I could implement this at the moment.
