### PR TITLE
register should never be replaced by an empty string

### DIFF
--- a/lib/operators/general-operators.coffee
+++ b/lib/operators/general-operators.coffee
@@ -54,7 +54,7 @@ class Operator
         text += '\n'
     else
       type = Utils.copyType(text)
-    @vimState.setRegister(register, {text, type})
+    @vimState.setRegister(register, {text, type}) unless text is ''
 
 # Public: Generic class for an operator that requires extra input
 class OperatorWithInput extends Operator

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -467,9 +467,10 @@ describe "Motions", ->
 
       it "doesn't go past the beginning of the file", ->
         editor.setCursorScreenPosition([0, 0])
+        vimState.setRegister('"', text: 'abc')
         keydown('y')
         keydown('B', shift: true)
-        expect(vimState.getRegister('"').text).toBe ''
+        expect(vimState.getRegister('"').text).toBe 'abc'
 
   describe "the ^ keybinding", ->
     beforeEach ->

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -621,6 +621,12 @@ describe "Operators", ->
       it "leaves the cursor at the starting position", ->
         expect(editor.getCursorScreenPosition()).toEqual [0, 4]
 
+      it "does not yank when motion fails", ->
+        keydown('y')
+        keydown('t')
+        commandModeInputKeydown('x')
+        expect(vimState.getRegister('"').text).toBe '345'
+
     describe "with a text object", ->
       it "moves the cursor to the beginning of the text object", ->
         editor.setCursorBufferPosition([0, 5])


### PR DESCRIPTION
when a motion fails or selects 0 characters, yank/delete/etc operators currently put “” in the appropriate register, but they shouldn’t do that