### PR TITLE
Fix delete with empty selections

### DIFF
--- a/lib/operators/general-operators.coffee
+++ b/lib/operators/general-operators.coffee
@@ -94,7 +94,8 @@ class Delete extends Operator
   execute: (count) ->
     if _.contains(@motion.select(count, @selectOptions), true)
       @setTextRegister(@register, @editor.getSelectedText())
-      @editor.delete()
+      for selection in @editor.getSelections()
+        selection.delete() unless selection.isEmpty()
       for cursor in @editor.getCursors()
         if @motion.isLinewise?()
           cursor.moveToBeginningOfLine()

--- a/lib/operators/general-operators.coffee
+++ b/lib/operators/general-operators.coffee
@@ -93,8 +93,7 @@ class Delete extends Operator
   # Returns nothing.
   execute: (count) ->
     if _.contains(@motion.select(count, @selectOptions), true)
-      text = @editor.getSelectedText()
-      @setTextRegister(@register, text)
+      @setTextRegister(@register, @editor.getSelectedText())
       @editor.delete()
       for cursor in @editor.getCursors()
         if @motion.isLinewise?()

--- a/lib/operators/input.coffee
+++ b/lib/operators/input.coffee
@@ -100,7 +100,8 @@ class Change extends Insert
         @editor.insertNewline()
         @editor.moveLeft()
       else
-        @editor.delete()
+        for selection in @editor.getSelections()
+          selection.delete() unless selection.isEmpty()
 
     return super if @typingCompleted
 

--- a/lib/operators/input.coffee
+++ b/lib/operators/input.coffee
@@ -117,8 +117,7 @@ class Substitute extends Insert
     @vimState.setInsertionCheckpoint() unless @typingCompleted
     _.times count, =>
       @editor.selectRight()
-    text = @editor.getLastSelection().getText()
-    @setTextRegister(@register, text)
+    @setTextRegister(@register, @editor.getSelectedText())
     @editor.delete()
 
     if @typingCompleted
@@ -140,8 +139,7 @@ class SubstituteLine extends Insert
     _.times count, =>
       @editor.selectToEndOfLine()
       @editor.selectRight()
-    text = @editor.getLastSelection().getText()
-    @setTextRegister(@register, text)
+    @setTextRegister(@register, @editor.getSelectedText())
     @editor.delete()
     @editor.insertNewlineAbove()
     @editor.getLastCursor().skipLeadingWhitespace()

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -390,7 +390,7 @@ describe "Operators", ->
 
     describe "with multiple cursors", ->
       it "deletes each selection", ->
-        editor.setText("abcd\n1234\nABCD")
+        editor.setText("abcd\n1234\nABCD\n")
         editor.setCursorBufferPosition([0, 1])
         editor.addCursorAtBufferPosition([1, 2])
         editor.addCursorAtBufferPosition([2, 3])
@@ -403,6 +403,23 @@ describe "Operators", ->
           [0, 0],
           [1, 1],
           [2, 2],
+        ]
+
+      it "doesn't delete empty selections", ->
+        editor.setText("abcd\nabc\nabd")
+        editor.setCursorBufferPosition([0, 0])
+        editor.addCursorAtBufferPosition([1, 0])
+        editor.addCursorAtBufferPosition([2, 0])
+
+        keydown('d')
+        keydown('t')
+        commandModeInputKeydown('d')
+
+        expect(editor.getText()).toBe "d\nabc\nd"
+        expect(editor.getCursorBufferPositions()).toEqual [
+          [0, 0],
+          [1, 0],
+          [2, 0],
         ]
 
   describe "the D keybinding", ->


### PR DESCRIPTION
With multiple cursors, if a motion selects nothing and other motions select something, delete operations would correctly delete the selections, but the empty selections would delete a character, which is unexpected. 
For example, with two cursors, `dtx` should delete until 'x' only on the line that has an 'x' - of only one does, the other line would delete a character; if neither line has x, nothing would be deleted. 
Another example: `d0` with two cursors, one at the beginning of the first line and another on the second line but not its beginning, should not delete the first character of the line.