### PR TITLE
Fix Till when selecting

### DIFF
--- a/lib/motions/find-motion.coffee
+++ b/lib/motions/find-motion.coffee
@@ -51,4 +51,17 @@ class Till extends Find
     super(@editor, @vimState)
     @offset = 1
 
+  match: ->
+    @selectAtLeastOne = false
+    retval = super
+    if retval? and not @backwards
+      @selectAtLeastOne = true
+    retval
+
+  moveSelectionInclusively: (selection, count, options) ->
+    super
+    if selection.isEmpty() and @selectAtLeastOne
+      selection.modifySelection ->
+        selection.cursor.moveRight()
+
 module.exports = {Find, Till}

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -1596,6 +1596,13 @@ describe "Motions", ->
       normalModeInputKeydown('b')
       expect(editor.getText()).toBe 'abcbcabc\n'
 
+    it "selects character under cursor even when no movement happens", ->
+      editor.setCursorBufferPosition([0, 0])
+      keydown('d')
+      keydown('t')
+      commandModeInputKeydown('b')
+      expect(editor.getText()).toBe 'bcabcabcabc\n'
+
   describe 'the V keybinding', ->
     beforeEach ->
       editor.setText("01\n002\n0003\n00004\n000005\n")

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -1600,7 +1600,7 @@ describe "Motions", ->
       editor.setCursorBufferPosition([0, 0])
       keydown('d')
       keydown('t')
-      commandModeInputKeydown('b')
+      normalModeInputKeydown('b')
       expect(editor.getText()).toBe 'bcabcabcabc\n'
 
   describe 'the V keybinding', ->


### PR DESCRIPTION
Till is an exceptional movement in that when selecting, it selects the current character even though it doesn't move the cursor. This was failing the normal selection machinery that expects cursor movements.
Fixes #618.