### PR TITLE
Repeating search with //, ?? et al.

### DIFF
--- a/docs/motions.md
+++ b/docs/motions.md
@@ -34,3 +34,4 @@
 * [T](http://vimhelp.appspot.com/motion.txt.html#T)
 * [;](http://vimhelp.appspot.com/motion.txt.html#%3B)
 * [,](http://vimhelp.appspot.com/motion.txt.html#%2C)
+* [/ and ?](http://vimhelp.appspot.com/pattern.txt.html#search-commands) (including `//` and `??`)

--- a/lib/motions/search-motion.coffee
+++ b/lib/motions/search-motion.coffee
@@ -76,10 +76,6 @@ class Search extends SearchBase
     super(@editor, @vimState)
     @viewModel = new SearchViewModel(@)
 
-  compose: (input) ->
-    super(input)
-    @viewModel.value = @input.characters
-
 class SearchCurrentWord extends SearchBase
   @keywordRegex: null
 

--- a/lib/view-models/search-view-model.coffee
+++ b/lib/view-models/search-view-model.coffee
@@ -30,5 +30,13 @@ class SearchViewModel extends ViewModel
       @restoreHistory(@historyIndex)
 
   confirm: (view) =>
+    repeatChar = if @searchMotion.initiallyReversed then '?' else '/'
+    if @view.value is '' or @view.value is repeatChar
+      lastSearch = @history(0)
+      if lastSearch?
+        @view.value = lastSearch
+      else
+        @view.value = ''
+        atom.beep()
     super(view)
-    @vimState.pushSearchHistory(@value)
+    @vimState.pushSearchHistory(@view.value)

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -998,6 +998,14 @@ describe "Motions", ->
         keydown('n')
         expect(editor.getCursorBufferPosition()).toEqual [1, 0]
 
+      it "uses ? as a literal string", ->
+        editor.setText("abc\n[a?c?\n")
+        keydown('/')
+        submitCommandModeInputText '?'
+        expect(editor.getCursorBufferPosition()).toEqual [1, 2]
+        keydown('n')
+        expect(editor.getCursorBufferPosition()).toEqual [1, 4]
+
       it 'works with selection in visual mode', ->
         editor.setText('one two three')
         keydown('v')
@@ -1067,6 +1075,16 @@ describe "Motions", ->
           keydown('/')
           submitCommandModeInputText 'def'
 
+        it "repeats previous search with /<enter>", ->
+          keydown('/')
+          submitCommandModeInputText('')
+          expect(editor.getCursorBufferPosition()).toEqual [3, 0]
+
+        it "repeats previous search with //", ->
+          keydown('/')
+          submitCommandModeInputText('/')
+          expect(editor.getCursorBufferPosition()).toEqual [3, 0]
+
         describe "the n keybinding", ->
           it "repeats the last search", ->
             keydown('n')
@@ -1101,10 +1119,30 @@ describe "Motions", ->
         submitCommandModeInputText('def')
         expect(editor.getCursorBufferPosition()).toEqual [3, 0]
 
+      it "accepts / as a literal search pattern", ->
+        editor.setText("abc\nd/f\nabc\nd/f\n")
+        editor.setCursorBufferPosition([0, 0])
+        keydown('?')
+        submitCommandModeInputText('/')
+        expect(editor.getCursorBufferPosition()).toEqual [3, 1]
+        keydown('?')
+        submitCommandModeInputText('/')
+        expect(editor.getCursorBufferPosition()).toEqual [1, 1]
+
       describe "repeating", ->
         beforeEach ->
           keydown('?')
           submitCommandModeInputText('def')
+
+        it "repeats previous search as reversed with ?<enter>", ->
+          keydown('?')
+          submitCommandModeInputText('')
+          expect(editor.getCursorBufferPosition()).toEqual [1, 0]
+
+        it "repeats previous search as reversed with ??", ->
+          keydown('?')
+          submitCommandModeInputText('?')
+          expect(editor.getCursorBufferPosition()).toEqual [1, 0]
 
         describe 'the n keybinding', ->
           it "repeats the last search backwards", ->


### PR DESCRIPTION
fixes #578 
Now search can be repeated with `/<enter>`, `//<enter>`, `?<enter>` and `??<enter>`.
Beyond that, I think I'm beginning to agree that / should be handled by ex-mode (#596).