### PR TITLE
add command shortcuts for save, close, and find/replace

### DIFF
--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -142,6 +142,10 @@
   '8': 'vim-mode:repeat-prefix'
   '9': 'vim-mode:repeat-prefix'
 
+  ': w enter': 'core:save'
+  ': q enter': 'core:close'
+  '/': 'find-and-replace:show'
+
 'atom-text-editor.vim-mode.command-mode':
   'i': 'vim-mode:activate-insert-mode'
   'v': 'vim-mode:activate-characterwise-visual-mode'


### PR DESCRIPTION
I'm loving vim-mode, but my fingers keep wanting to do ":w" and ":q" to save and close a pane.  This adds those key mappings.  I also added a "/" key mapping that brings up the find/replace panel.