### PR TITLE
Add short highlight when text is yanked

### DIFF
--- a/lib/operators/general-operators.coffee
+++ b/lib/operators/general-operators.coffee
@@ -200,6 +200,11 @@ class Yank extends Operator
 
     @setTextRegister(@register, text)
 
+    marker = @editor.markBufferRange(@editor.getSelectedBufferRange(), invalidate: 'touch')
+    yankHighlight = @editor.decorateMarker(marker, type: 'highlight', class: 'yank-highlight')
+
+    setTimeout (-> yankHighlight.destroy()), 300
+
     @editor.setSelectedBufferRanges(newPositions.map (p) -> new Range(p, p))
     @vimState.activateCommandMode()
 

--- a/styles/vim-mode.less
+++ b/styles/vim-mode.less
@@ -56,3 +56,11 @@ atom-text-editor.vim-mode.visual-mode
     }
   }
 }
+
+atom-text-editor,
+atom-text-editor::shadow {
+  .yank-highlight .region {
+    border-radius: @component-border-radius;
+    border: 1px solid @syntax-result-marker-color;
+  }
+}


### PR DESCRIPTION
When text gets yanked, a short highlight appears as a small visual aid. Inspired by the Vintageous package from Sublime Text.

The only problem is that I could not figure out how to write specs for this feature. The specs in this [example repo](https://github.com/atom/decoration-example/blob/master/spec/decoration-example-spec.coffee) all seem to be using the Atom WorkspaceView, but the operators-spec.coffee seems to be using another way to initialise the editor. I also got quite some deprecation warnings while running the package specs.

So this feature should work, but there are no specs yet.
