### PR TITLE
fix deprecation of editor.getUri

### DIFF
--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -276,7 +276,7 @@ class VimState
       type = Utils.copyType(text)
       {text, type}
     else if name is '%'
-      text = @editor.getUri()
+      text = @editor.getURI()
       type = Utils.copyType(text)
       {text, type}
     else if name is "_" # Blackhole always returns nothing

--- a/spec/prefixes-spec.coffee
+++ b/spec/prefixes-spec.coffee
@@ -136,7 +136,7 @@ describe "Prefixes", ->
 
     describe "the % register", ->
       beforeEach ->
-        spyOn(editor, 'getUri').andReturn('/Users/atom/known_value.txt')
+        spyOn(editor, 'getURI').andReturn('/Users/atom/known_value.txt')
 
       describe "reading", ->
         it "returns the filename of the current editor", ->


### PR DESCRIPTION
with `apm test -1` I've uncovered another use of a deprecated method, this fixes it.
How does one add `-1` to `apm test` in Travis tests?