### PR TITLE
make dd leave cursor on nonblank char

### DIFF
--- a/lib/operators/general-operators.coffee
+++ b/lib/operators/general-operators.coffee
@@ -98,7 +98,7 @@ class Delete extends Operator
         selection.deleteSelectedText()
       for cursor in @editor.getCursors()
         if @motion.isLinewise?()
-          cursor.moveToBeginningOfLine()
+          cursor.skipLeadingWhitespace()
         else
           cursor.moveLeft() if cursor.isAtEndOfLine() and not cursor.isAtBeginningOfLine()
 

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -677,8 +677,7 @@ describe "Motions", ->
 
         it "deletes the current line plus that many previous lines", ->
           expect(editor.getText()).toBe "1\n6\n"
-          # commented out because the column is wrong due to a bug in `k`; re-enable when `k` is fixed
-          #expect(editor.getCursorScreenPosition()).toEqual [1, 0]
+          expect(editor.getCursorScreenPosition()).toEqual [1, 0]
 
   describe "the + keybinding", ->
     beforeEach ->
@@ -738,8 +737,7 @@ describe "Motions", ->
 
         it "selects to the first character of the next line", ->
           expect(editor.getText()).toBe "abcdefg\n"
-          # commented out because the column is wrong due to a bug in `j`; re-enable when `j` is fixed
-          #expect(editor.getCursorScreenPosition()).toEqual [0, 0]
+          expect(editor.getCursorScreenPosition()).toEqual [0, 0]
 
     describe "with a count", ->
       beforeEach ->
@@ -762,8 +760,7 @@ describe "Motions", ->
 
         it "deletes the current line plus that many following lines", ->
           expect(editor.getText()).toBe "1\n6\n"
-          # commented out because the column is wrong due to a bug in `j`; re-enable when `j` is fixed
-          #expect(editor.getCursorScreenPosition()).toEqual [1, 0]
+          expect(editor.getCursorScreenPosition()).toEqual [1, 0]
 
   describe "the _ keybinding", ->
     beforeEach ->

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -328,6 +328,16 @@ describe "Operators", ->
         expect(editor.getText()).toBe "12345\nabcde\n"
         expect(editor.getCursorScreenPosition()).toEqual [2, 0]
 
+      it "leaves the cursor on the first nonblank character", ->
+        editor.setText("12345\n  abcde\n")
+        editor.setCursorScreenPosition([0, 4])
+
+        keydown('d')
+        keydown('d')
+
+        expect(editor.getText()).toBe "  abcde\n"
+        expect(editor.getCursorScreenPosition()).toEqual [0, 2]
+
     describe "undo behavior", ->
       beforeEach ->
         editor.setText("12345\nabcde\nABCDE\nQWERT")


### PR DESCRIPTION
Default Vim behavior is to move to the first nonblank character in the line.
Also, here seems to be a plugin that causes Vim to leave the cursor in the
same column if possible.  vim-mode's old behavior did neither.

This PR makes vim-mode work just like stock vim.