### PR TITLE
don't moveLeft() if selection.isReversed()

### DIFF
--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -415,7 +415,7 @@ class VimState
   deactivateVisualMode: ->
     return unless @mode is 'visual'
     for selection in @editor.getSelections()
-      selection.cursor.moveLeft() unless selection.isEmpty()
+      selection.cursor.moveLeft() unless (selection.isEmpty() or selection.isReversed())
 
   # Private: Get the input operator that needs to be told about about the
   # typed undo transaction in a recently completed operation, if there

--- a/spec/vim-state-spec.coffee
+++ b/spec/vim-state-spec.coffee
@@ -231,6 +231,16 @@ describe "VimState", ->
       expect(editorElement.classList.contains('command-mode')).toBe(true)
       expect(editorElement.classList.contains('visual-mode')).toBe(false)
 
+    it "puts the editor into command mode when <escape> is pressed on selection is reversed", ->
+      expect(editor.getSelectedText()).toBe("t")
+      keydown("h")
+      keydown("h")
+      expect(editor.getSelectedText()).toBe("e t")
+      expect(editor.getLastSelection().isReversed()).toBe(true)
+      keydown('escape')
+      expect(editorElement.classList.contains('command-mode')).toBe(true)
+      expect(editor.getCursorBufferPositions()).toEqual [[0, 2]]
+
     describe "motions", ->
       it "transforms the selection", ->
         keydown('w')


### PR DESCRIPTION
Before this change, `deactivateVisualMode()` unnecessarily move cursor Left when selection is Reversed.

## Reproduce
* `v` to enter visual-mode
* `kk`, `esc` move Cursor one column **Left** position to expected position.

This PR fix above bug.
All test pass, I don't think additional test required for this fix.