### PR TITLE
Fix p cursor position

### DIFF
--- a/lib/operators/put-operator.coffee
+++ b/lib/operators/put-operator.coffee
@@ -58,9 +58,9 @@ class Put extends Operator
       @editor.setCursorScreenPosition(originalPosition)
       @editor.moveToFirstCharacterOfLine()
 
-    @vimState.activateNormalMode()
     if type isnt 'linewise'
       @editor.moveLeft()
+    @vimState.activateNormalMode()
 
   # Private: Helper to determine if the editor is currently on the last row.
   #

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -947,6 +947,15 @@ describe "Operators", ->
           expect(editor.getText()).toBe "034512\n"
           expect(editor.getCursorScreenPosition()).toEqual [0, 3]
 
+      describe "at the end of a line", ->
+        beforeEach ->
+          editor.setCursorScreenPosition [0, 2]
+          keydown('p')
+
+        it "positions cursor correctly", ->
+          expect(editor.getText()).toBe "012345\n"
+          expect(editor.getCursorScreenPosition()).toEqual [0, 5]
+
       describe "when useClipboardAsDefaultRegister enabled", ->
         it "inserts contents from clipboard", ->
           atom.config.set 'vim-mode.useClipboardAsDefaultRegister', true


### PR DESCRIPTION
If you have a word in the clipboard and `p` it at the end of the line, the cursor ends up on the second-to-last character of the word, not on the last one, as expected. This PR fixes that.