### PR TITLE
Fix insert redo

### DIFF
--- a/lib/operators/input.coffee
+++ b/lib/operators/input.coffee
@@ -12,7 +12,7 @@ class Insert extends Operator
   isComplete: -> @standalone or super
 
   confirmChanges: (changes) ->
-    bundler = new TransactionBundler(changes)
+    bundler = new TransactionBundler(changes, @editor)
     @typedText = bundler.buildInsertText()
 
   execute: ->
@@ -155,32 +155,70 @@ class SubstituteLine extends Insert
 # Takes a transaction and turns it into a string of what was typed.
 # This class is an implementation detail of Insert
 class TransactionBundler
-  constructor: (@changes) ->
-    @position = null
-    @content = ""
+  constructor: (@changes, @editor) ->
+    @start = null
+    @end = null
 
   buildInsertText: ->
     @addChange(change) for change in @changes
-    @content
+    if @start?
+      @editor.getTextInBufferRange [@start, @end]
+    else
+      ""
 
   addChange: (change) ->
     return unless change.newRange?
-    if @isAppending(change)
-      @content += change.newText
-      @position = change.newRange.end
-    else if @isRemovingFromEnd(change)
-      @content = @content.substring(0, @content.length - change.oldText.length)
-      @position = change.newRange.end
+    if @isAddingWithinPrevious(change)
+      @addRange change.newRange
+    if @isRemovingFromPrevious(change)
+      @subtractRange change.oldRange
 
-  isAppending: (change) ->
+  isAddingWithinPrevious: (change) ->
+    return false unless @isAdding(change)
+
+    return true if @start is null
+
+    @start.isLessThanOrEqual(change.newRange.start) and
+      @end.isGreaterThanOrEqual(change.newRange.start)
+
+  isRemovingFromPrevious: (change) ->
+    return false unless @isRemoving(change) and @start?
+
+    @start.isLessThanOrEqual(change.oldRange.start) and
+      @end.isGreaterThanOrEqual(change.oldRange.end)
+
+  isAdding: (change) ->
     (change.newText.length > 0) and
-      (change.oldText.length is 0) and
-      ((not @position) or @position.isEqual(change.newRange.start))
+      (change.oldText.length is 0)
 
-  isRemovingFromEnd: (change) ->
+  isRemoving: (change) ->
     (change.newText.length is 0) and
-      (change.oldText.length > 0) and
-      (@position and @position?.isEqual(change.oldRange.end))
+      (change.oldText.length > 0)
+
+  addRange: (range) ->
+    if @start is null
+      {@start, @end} = range
+      return
+
+    rows = range.end.row - range.start.row
+
+    if (range.start.row is @end.row)
+      cols = range.end.column - range.start.column
+    else
+      cols = 0
+
+    @end = @end.translate [rows, cols]
+
+  subtractRange: (range) ->
+    rows = range.end.row - range.start.row
+
+    if (range.end.row is @end.row)
+      cols = range.end.column - range.start.column
+    else
+      cols = 0
+
+    @end = @end.translate [-rows, -cols]
+
 
 module.exports = {
   Insert,

--- a/lib/operators/input.coffee
+++ b/lib/operators/input.coffee
@@ -168,10 +168,10 @@ class TransactionBundler
 
   addChange: (change) ->
     return unless change.newRange?
-    if @isAddingWithinPrevious(change)
-      @addRange change.newRange
     if @isRemovingFromPrevious(change)
       @subtractRange change.oldRange
+    if @isAddingWithinPrevious(change)
+      @addRange change.newRange
 
   isAddingWithinPrevious: (change) ->
     return false unless @isAdding(change)
@@ -188,12 +188,10 @@ class TransactionBundler
       @end.isGreaterThanOrEqual(change.oldRange.end)
 
   isAdding: (change) ->
-    (change.newText.length > 0) and
-      (change.oldText.length is 0)
+    change.newText.length > 0
 
   isRemoving: (change) ->
-    (change.newText.length is 0) and
-      (change.oldText.length > 0)
+    change.oldText.length > 0
 
   addRange: (range) ->
     if @start is null

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -1550,7 +1550,9 @@ describe "Operators", ->
       expect(editor.getText()).toBe "abc123\nabc4567"
 
       keydown 'i'
-      editor.insertText("def")
+      editor.insertText "d"
+      editor.insertText "e"
+      editor.insertText "f"
       keydown 'escape'
       expect(editor.getText()).toBe "abdefc123\nabdefc4567"
 
@@ -1573,6 +1575,27 @@ describe "Operators", ->
 
       keydown '.'
       expect(editor.getText()).toBe "abababccc123\nabababccc4567"
+
+    describe 'with nonlinear input', ->
+      beforeEach ->
+        editor.setText ''
+        editor.setCursorBufferPosition [0, 0]
+
+      it 'deals with auto-matched brackets', ->
+        keydown 'i'
+        # this sequence simulates what the bracket-matcher package does
+        # when the user types (a)b<enter>
+        editor.insertText '()'
+        editor.moveLeft()
+        editor.insertText 'a'
+        editor.moveRight()
+        editor.insertText 'b\n'
+        keydown 'escape'
+        expect(editor.getCursorScreenPosition()).toEqual [1,  0]
+
+        keydown '.'
+        expect(editor.getText()).toBe '(a)b\n(a)b\n'
+        expect(editor.getCursorScreenPosition()).toEqual [2,  0]
 
   describe 'the a keybinding', ->
     beforeEach ->

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -1597,6 +1597,21 @@ describe "Operators", ->
         expect(editor.getText()).toBe '(a)b\n(a)b\n'
         expect(editor.getCursorScreenPosition()).toEqual [2,  0]
 
+      it 'deals with autocomplete', ->
+        keydown 'i'
+        # this sequence simulates autocompletion of 'add' to 'addFoo'
+        editor.insertText 'a'
+        editor.insertText 'd'
+        editor.insertText 'd'
+        editor.setTextInBufferRange [[0, 0], [0, 3]], 'addFoo'
+        keydown 'escape'
+        expect(editor.getCursorScreenPosition()).toEqual [0,  5]
+        expect(editor.getText()).toBe 'addFoo'
+
+        keydown '.'
+        expect(editor.getText()).toBe 'addFoaddFooo'
+        expect(editor.getCursorScreenPosition()).toEqual [0,  10]
+
   describe 'the a keybinding', ->
     beforeEach ->
       editor.setText('')


### PR DESCRIPTION
This fixes the problem where bracket-matcher's autocompletion of quotes or brackets would confuse replay of inserts. This is mentioned in #392, #650, and related to #564.