### PR TITLE
fix Uncaught NotFoundError

### DIFF
--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -210,8 +210,8 @@ class VimState
       # if we have started an operation that responds to canComposeWith check if it can compose
       # with the operation we're going to push onto the stack
       if (topOp = @topOperation())? and topOp.canComposeWith? and not topOp.canComposeWith(operation)
-        @emitter.emit('failed-to-compose')
         @resetCommandMode()
+        @emitter.emit('failed-to-compose')
         break
 
       @opStack.push(operation)


### PR DESCRIPTION
The error was caused by event handlers of `failed-to-compose` cancelling the operation that’s already being cancelled.

Replicate the issue by pressing `cm`.

May be what caused #713, #646, #642 - and certainly is the one described in #633.