### PR TITLE
make find state global

### DIFF
--- a/lib/global-vim-state.coffee
+++ b/lib/global-vim-state.coffee
@@ -3,3 +3,4 @@ class GlobalVimState
   registers: {}
   searchHistory: []
   currentSearch: {}
+  currentFind: null

--- a/lib/motions/find-motion.coffee
+++ b/lib/motions/find-motion.coffee
@@ -3,14 +3,25 @@
 {Point, Range} = require 'atom'
 
 class Find extends MotionWithInput
-  constructor: (@editor, @vimState) ->
+  constructor: (@editor, @vimState, opts={}) ->
     super(@editor, @vimState)
-    @vimState.currentFind = this
-    @viewModel = new ViewModel(this, class: 'find', singleChar: true, hidden: true)
-    @backwards = false
-    @repeatReversed = false
     @offset = 0
-    @repeated = false
+
+    if not opts.repeated
+      @viewModel = new ViewModel(this, class: 'find', singleChar: true, hidden: true)
+      @backwards = false
+      @repeated = false
+      @vimState.globalVimState.currentFind = this
+
+    else
+      @repeated = true
+
+      orig = @vimState.globalVimState.currentFind
+      @backwards = orig.backwards
+      @complete = orig.complete
+      @input = orig.input
+
+      @reverse() if opts.reverse
 
   match: (cursor, count) ->
     currentPosition = cursor.getBufferPosition()
@@ -38,17 +49,9 @@ class Find extends MotionWithInput
     if (match = @match(cursor, count))?
       cursor.setBufferPosition(match)
 
-  repeat: (opts={}) ->
-    opts.reverse = !!opts.reverse
-    @repeated = true
-    if opts.reverse isnt @repeatReversed
-      @reverse()
-      @repeatReversed = opts.reverse
-    this
-
 class Till extends Find
-  constructor: (@editor, @vimState) ->
-    super(@editor, @vimState)
+  constructor: (@editor, @vimState, opts={}) ->
+    super(@editor, @vimState, opts)
     @offset = 1
 
   match: ->

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -177,8 +177,8 @@ class VimState
       'find-backwards': (e) => new Motions.Find(@editor, this).reverse()
       'till': (e) => new Motions.Till(@editor, this)
       'till-backwards': (e) => new Motions.Till(@editor, this).reverse()
-      'repeat-find': (e) => @currentFind.repeat() if @currentFind?
-      'repeat-find-reverse': (e) => @currentFind.repeat(reverse: true) if @currentFind?
+      'repeat-find': (e) => new @globalVimState.currentFind.constructor(@editor, this, repeated: true) if @globalVimState.currentFind
+      'repeat-find-reverse': (e) => new @globalVimState.currentFind.constructor(@editor, this, repeated: true, reverse: true) if @globalVimState.currentFind
       'replace': (e) => new Operators.Replace(@editor, this)
       'search': (e) => new Motions.Search(@editor, this)
       'reverse-search': (e) => (new Motions.Search(@editor, this)).reversed()

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -1744,6 +1744,25 @@ describe "Motions", ->
       keydown(',')
       expect(editor.getCursorScreenPosition()).toEqual [0, 2]
 
+    it "gets state from GlobalVimState", ->
+      keydown('f')
+      normalModeInputKeydown('c')
+      expect(editor.getCursorScreenPosition()).toEqual [0, 2]
+
+      # store the current find for 'c'
+      findFC = vimState.globalVimState.currentFind
+
+      keydown('t')
+      normalModeInputKeydown('b')
+      expect(editor.getCursorScreenPosition()).toEqual [0, 3]
+      keydown(';')
+      expect(editor.getCursorScreenPosition()).toEqual [0, 6]
+
+      # simulate a find for 'c' being done elsewhere
+      vimState.globalVimState.currentFind = findFC
+      keydown(';')
+      expect(editor.getCursorScreenPosition()).toEqual [0, 8]
+
   describe 'the % motion', ->
     beforeEach ->
       editor.setText("( ( ) )--{ text in here; and a function call(with parameters) }\n")

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -3,8 +3,12 @@ GlobalVimState = require '../lib/global-vim-state'
 VimMode  = require '../lib/vim-mode'
 StatusBarManager = require '../lib/status-bar-manager'
 
+[globalVimState, statusBarManager] = []
+
 beforeEach ->
   atom.workspace ||= {}
+  statusBarManager = null
+  globalVimState = null
 
 getEditorElement = (callback) ->
   textEditor = null
@@ -17,7 +21,9 @@ getEditorElement = (callback) ->
     element = document.createElement("atom-text-editor")
     element.setModel(textEditor)
     element.classList.add('vim-mode')
-    element.vimState = new VimState(element, new StatusBarManager, new GlobalVimState)
+    statusBarManager ?= new StatusBarManager
+    globalVimState ?= new GlobalVimState
+    element.vimState = new VimState(element, statusBarManager, globalVimState)
 
     element.addEventListener "keydown", (e) ->
       atom.keymaps.handleKeyboardEvent(e)


### PR DESCRIPTION
Makes find state global, like search state (history) is shared across text editors.
An example: if you do `t*` to move the cursor to the next `*` in one editor, switch to another editor, and do `;`, you'll go to the next `*` as well.