### PR TITLE
Implement Ctrl-^ to switch to the most recently visible tab.

### DIFF
--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -112,6 +112,8 @@
   'ctrl-w q': 'core:close'
   'g t': 'pane:show-next-item'
   'g T': 'pane:show-previous-item'
+  'ctrl-6': 'vim-mode:focus-recent-tab'
+  'ctrl-^': 'vim-mode:focus-recent-tab'
 
   'm': 'vim-mode:mark'
   '`': 'vim-mode:move-to-mark-literal'

--- a/lib/motions/index.coffee
+++ b/lib/motions/index.coffee
@@ -2,6 +2,7 @@ Motions = require './general-motions'
 {Search, SearchCurrentWord, BracketMatchingMotion, RepeatSearch} = require './search-motion'
 MoveToMark = require './move-to-mark-motion'
 {Find, Till} = require './find-motion'
+Pane = require './pane-motion'
 
 Motions.Search = Search
 Motions.SearchCurrentWord = SearchCurrentWord
@@ -10,5 +11,6 @@ Motions.RepeatSearch = RepeatSearch
 Motions.MoveToMark = MoveToMark
 Motions.Find = Find
 Motions.Till = Till
+Motions.Pane = Pane
 
 module.exports = Motions

--- a/lib/motions/pane-motion.coffee
+++ b/lib/motions/pane-motion.coffee
@@ -1,0 +1,21 @@
+module.exports =
+class Pane
+  constructor: (@editor, @vimState) ->
+
+  execute: (count) ->
+    if count
+      atom.workspace.getActivePane().activateItemAtIndex(count-1)
+    else
+      activeEditor = atom.workspace.getActiveTextEditor()
+      editors = atom.workspace.getTextEditors()
+      editors = (editor for editor in editors when editor isnt activeEditor)
+      editors = editors.sort (a, b) -> b.lastOpened - a.lastOpened
+      @activateEditor(editors[0])
+
+  activateEditor: (item) ->
+    for pane in atom.workspace.getPanes()
+      index = pane.getItems().indexOf(item)
+      pane.activateItemAtIndex(index) if index?
+
+  isComplete: -> true
+  isRecordable: -> false

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -173,6 +173,7 @@ class VimState
       'search-current-word': (e) => new Motions.SearchCurrentWord(@editor, this)
       'bracket-matching-motion': (e) => new Motions.BracketMatchingMotion(@editor, this)
       'reverse-search-current-word': (e) => (new Motions.SearchCurrentWord(@editor, this)).reversed()
+      'focus-recent-tab': (e) => new Motions.Pane(@editor, this)
 
   # Private: Register multiple command handlers via an {Object} that maps
   # command names to command handler functions.


### PR DESCRIPTION
Implement Ctrl-^ to switch to the most recently visible tab.

Vim's docs claim: `Edit the alternate file. Mostly the alternate file is the previously edited file.` However, experimentation shows that editing doesn't seem to matter.  The alternate file actually appears to be the previously viewed file.

Writing the feature was easy, but writing the tests has beaten me.  @maxbrunsfeld, would appreciate a little guidance when you get a chance.

When mergeable, this should address https://github.com/atom/vim-mode/issues/719