### PR TITLE
Implement gf (goto file)

### DIFF
--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -131,6 +131,8 @@
   'n': 'vim-mode:repeat-search'
   'N': 'vim-mode:repeat-search-backwards'
 
+  'g f': 'vim-mode:open-file-under-cursor'
+
   '%': 'vim-mode:bracket-matching-motion'
 
   '1': 'vim-mode:repeat-prefix'

--- a/lib/motions/index.coffee
+++ b/lib/motions/index.coffee
@@ -2,6 +2,7 @@ Motions = require './general-motions'
 {Search, SearchCurrentWord, BracketMatchingMotion, RepeatSearch} = require './search-motion'
 MoveToMark = require './move-to-mark-motion'
 {Find, Till} = require './find-motion'
+OpenFileUnderCursor = require './open-file-under-cursor'
 
 Motions.Search = Search
 Motions.SearchCurrentWord = SearchCurrentWord
@@ -10,5 +11,6 @@ Motions.RepeatSearch = RepeatSearch
 Motions.MoveToMark = MoveToMark
 Motions.Find = Find
 Motions.Till = Till
+Motions.OpenFileUnderCursor = OpenFileUnderCursor
 
 module.exports = Motions

--- a/lib/motions/open-file-under-cursor.coffee
+++ b/lib/motions/open-file-under-cursor.coffee
@@ -3,6 +3,7 @@ path = require 'path'
 {Directory} = require 'atom'
 shell = require 'shell'
 {exec} = require 'child_process'
+utils = require '../utils'
 
 class OpenFileUnderCursor extends Motion
   execute: (count) ->
@@ -17,8 +18,11 @@ class OpenFileUnderCursor extends Motion
     ###
     wordRegex = /[a-z0-9\.\-_\/\\%:]+/i
     @editor.getCursors().forEach (cursor) =>
-      range = cursor.getCurrentWordBufferRange wordRegex: wordRegex
-      selectedPath = @editor.getTextInRange range
+      currentWord = utils.getCurrentWord @editor, cursor, wordRegex
+      # range = cursor.getCurrentWordBufferRange wordRegex: wordRegex
+      # selectedPath = @editor.getTextInRange range
+      range = currentWord.range
+      selectedPath = currentWord.word
 
       # exit early for url match
       if /^https?:/i.test(selectedPath)

--- a/lib/motions/open-file-under-cursor.coffee
+++ b/lib/motions/open-file-under-cursor.coffee
@@ -1,0 +1,54 @@
+{Motion} = require './general-motions'
+path = require 'path'
+{Directory} = require 'atom'
+shell = require 'shell'
+{exec} = require 'child_process'
+
+class OpenFileUnderCursor extends Motion
+  execute: (count) ->
+    ###
+      /usr/bin/test
+      ../../.travis.yml
+      ./search-motion
+      ./index
+      http://github.com
+      https://thing.com/item%20test
+      //github.com
+    ###
+    wordRegex = /[a-z0-9\.\-_\/\\%:]+/i
+    for cursor in @editor.getCursors()
+      range = cursor.getCurrentWordBufferRange wordRegex: wordRegex
+      selectedPath = @editor.getTextInRange range
+
+      # exit early for url match
+      if /^https?:/i.test(selectedPath)
+        return @openUrl selectedPath
+      if /^\/\//i.test(selectedPath)
+        return @openUrl "http:#{selectedPath}"
+
+      if selectedPath[0] isnt '/' and selectedPath[0] isnt '\\'
+        selectedPath = path.join path.dirname(@editor.buffer.file.path), selectedPath
+
+      pathDir = path.dirname selectedPath
+      dir = new Directory pathDir
+      ext = path.extname @editor.buffer.file.path
+      dir.getEntries (err, entries) =>
+        # find any paths that contain the selected path
+        matches = entries.filter (entry) -> entry.path.indexOf(selectedPath) > -1
+        return @loadFile matches[0].path if matches.length is 1
+
+        # if there are other possible matches, try to match on extension
+        extMatches = matches.filter (entry) -> path.extname(entry.path) is ext
+        return @loadFile extMatches[0].path if extMatches.length is 1
+
+  loadFile: (path) -> atom.workspace.open path
+
+  openUrl: (url) ->
+    # pulled from https://github.com/magbicaleman/open-in-browser/blob/master/lib/open-in-browser.coffee
+    process_architecture = process.platform
+    switch process_architecture
+      when 'darwin' then exec "open '#{url}'"
+      when 'linux' then exec "xdg-open '#{url}'"
+      when 'win32' then shell.openExternal url
+
+module.exports = OpenFileUnderCursor

--- a/lib/motions/open-file-under-cursor.coffee
+++ b/lib/motions/open-file-under-cursor.coffee
@@ -16,7 +16,7 @@ class OpenFileUnderCursor extends Motion
       //github.com
     ###
     wordRegex = /[a-z0-9\.\-_\/\\%:]+/i
-    for cursor in @editor.getCursors()
+    @editor.getCursors().forEach (cursor) =>
       range = cursor.getCurrentWordBufferRange wordRegex: wordRegex
       selectedPath = @editor.getTextInRange range
 

--- a/lib/motions/search-motion.coffee
+++ b/lib/motions/search-motion.coffee
@@ -4,6 +4,7 @@ SearchViewModel = require '../view-models/search-view-model'
 {Input} = require '../view-models/view-model'
 {Point, Range} = require 'atom'
 settings = require '../settings'
+utils = require '../utils'
 
 class SearchBase extends MotionWithInput
   operatesInclusively: false
@@ -92,22 +93,8 @@ class SearchCurrentWord extends SearchBase
     @vimState.pushSearchHistory(searchString) unless searchString is @vimState.getSearchHistoryItem()
 
   getCurrentWord: ->
-    cursor = @editor.getLastCursor()
-    wordStart = cursor.getBeginningOfCurrentWordBufferPosition(wordRegex: @keywordRegex, allowPrevious: false)
-    wordEnd   = cursor.getEndOfCurrentWordBufferPosition      (wordRegex: @keywordRegex, allowNext: false)
-    cursorPosition = cursor.getBufferPosition()
-
-    if wordEnd.column is cursorPosition.column
-      # either we don't have a current word, or it ends on cursor, i.e. precedes it, so look for the next one
-      wordEnd = cursor.getEndOfCurrentWordBufferPosition      (wordRegex: @keywordRegex, allowNext: true)
-      return "" if wordEnd.row isnt cursorPosition.row # don't look beyond the current line
-
-      cursor.setBufferPosition wordEnd
-      wordStart = cursor.getBeginningOfCurrentWordBufferPosition(wordRegex: @keywordRegex, allowPrevious: false)
-
-    cursor.setBufferPosition wordStart
-
-    @editor.getTextInBufferRange([wordStart, wordEnd])
+    {word} = utils.getCurrentWord @editor, @editor.getLastCursor(), @keywordRegex
+    return word
 
   cursorIsOnEOF: (cursor) ->
     pos = cursor.getNextWordBoundaryBufferPosition(wordRegex: @keywordRegex)

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -12,3 +12,35 @@ module.exports =
       'linewise'
     else
       'character'
+
+  # Public: Return the word that the cursor is currently inside of
+  #
+  # editor - Editor instance to use
+  # cursor - Cursor the word should be searched via
+  # keywordRegex - [optional] RegEx to decide "what" a word is
+  #
+  # Returns {word, range} for the discovered content or null if not found
+  getCurrentWord: (editor, cursor, keywordRegex) ->
+    if not keywordRegex
+      defaultIsKeyword = "[@a-zA-Z0-9_\-]+"
+      userIsKeyword = atom.config.get('vim-mode.iskeyword')
+      keywordRegex = new RegExp(userIsKeyword or defaultIsKeyword)
+
+    wordStart = cursor.getBeginningOfCurrentWordBufferPosition(wordRegex: keywordRegex, allowPrevious: false)
+    wordEnd   = cursor.getEndOfCurrentWordBufferPosition      (wordRegex: keywordRegex, allowNext: false)
+    cursorPosition = cursor.getBufferPosition()
+
+    if wordEnd.column is cursorPosition.column
+      # either we don't have a current word, or it ends on cursor, i.e. precedes it, so look for the next one
+      wordEnd = cursor.getEndOfCurrentWordBufferPosition      (wordRegex: keywordRegex, allowNext: true)
+      return null if wordEnd.row isnt cursorPosition.row # don't look beyond the current line
+
+      cursor.setBufferPosition wordEnd
+      wordStart = cursor.getBeginningOfCurrentWordBufferPosition(wordRegex: keywordRegex, allowPrevious: false)
+
+    cursor.setBufferPosition wordStart
+
+    {
+      word: editor.getTextInBufferRange([wordStart, wordEnd])
+      range: [wordStart, wordEnd]
+    }

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -173,6 +173,7 @@ class VimState
       'search-current-word': (e) => new Motions.SearchCurrentWord(@editor, this)
       'bracket-matching-motion': (e) => new Motions.BracketMatchingMotion(@editor, this)
       'reverse-search-current-word': (e) => (new Motions.SearchCurrentWord(@editor, this)).reversed()
+      'open-file-under-cursor': (e) => new Motions.OpenFileUnderCursor(@editor, this)
 
   # Private: Register multiple command handlers via an {Object} that maps
   # command names to command handler functions.


### PR DESCRIPTION
This implements the gf keybinding which will allow the editor to open the file or url under the cursor. It supports absolute file paths, relative file paths, and even paths without an extension. If no extension is found, but multiple files are found with the same name (i.e. main.js or main.coffee), it will look to the currently loaded file for advice on the extension to use.

I've run into an issue where I can't seem to get tests to work properly. The situation is that in order for relative paths to work, there needs to be an actual file (from the file system) loaded into the editor. Any suggestions on how to get that working? I'd also need to be able to test that once the command is entered new files open as well.
