### PR TITLE
Make control-t return from symbol, not control-shift-t

### DIFF
--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -162,7 +162,7 @@
   '.': 'vim-mode:repeat'
 
   'ctrl-]': 'symbols-view:go-to-declaration'
-  'ctrl-T': 'symbols-view:return-from-declaration'
+  'ctrl-t': 'symbols-view:return-from-declaration'
 
   'ctrl-a': 'vim-mode:increase'
   'ctrl-x': 'vim-mode:decrease'


### PR DESCRIPTION
This updates vim-mode to match Vim's binding.

I assume this was a simple typo?  https://github.com/atom/vim-mode/commit/c35d2d6744c3beaa91f8bc9e82ee19f11680478b
