### PR TITLE
make tests fail if deprecated calls are made

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     }
   },
   "devDependencies": {
-    "coffeelint": "^1.10.1"
+    "coffeelint": "^1.10.1",
+    "grim": "^1.2.1"
   }
 }

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -2,9 +2,17 @@ VimState = require '../lib/vim-state'
 GlobalVimState = require '../lib/global-vim-state'
 VimMode  = require '../lib/vim-mode'
 StatusBarManager = require '../lib/status-bar-manager'
+Grim = require 'grim'
 
 beforeEach ->
   atom.workspace ||= {}
+
+afterEach ->
+  if Grim.getDeprecationsLength() > 0
+    Grim.logDeprecations()
+    Grim.clearDeprecations()
+    this.fail 'Deprecated APIs were called'
+
 
 getEditorElement = (callback) ->
   textEditor = null


### PR DESCRIPTION
Happy to say, master doesn't call any deprecated APIs (while testing anyway).

But this might be needed soon...  there are some pull requests that do.
