### PR TITLE
fix redoing visual mode operations with `.`

### DIFF
--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -136,17 +136,10 @@ class CurrentSelection extends Motion
 
   selectCharacters: ->
     lastSelectionExtent = @lastSelectionRange.getExtent()
-    wrap = settings.wrapLeftRightMotion()
     for selection in @editor.getSelections()
       {start} = selection.getBufferRange()
       newEnd = start.traverse(lastSelectionExtent)
       selection.setBufferRange([start, newEnd])
-
-      if wrap
-        columnDifference = newEnd.column - selection.getBufferRange().end.column
-        if columnDifference > 0
-          _.times columnDifference, -> selection.selectRight()
-
     return
 
 # Public: Generic class for motions that require extra input

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -1599,6 +1599,24 @@ describe "Motions", ->
       normalModeInputKeydown('b')
       expect(editor.getText()).toBe 'bcabcabcabc\n'
 
+  describe 'the v keybinding', ->
+    beforeEach ->
+      editor.setText("01\n002\n0003\n00004\n000005\n")
+      editor.setCursorScreenPosition([1, 1])
+
+    it "selects down a line", ->
+      keydown('v')
+      keydown('j')
+      keydown('j')
+      expect(editor.getSelectedText()).toBe "02\n0003\n00"
+      expect(editor.getSelectedBufferRange().isSingleLine()).toBeFalsy()
+
+    it "selects right", ->
+      keydown('v')
+      keydown('l')
+      expect(editor.getSelectedText()).toBe "02"
+      expect(editor.getSelectedBufferRange().isSingleLine()).toBeTruthy()
+
   describe 'the V keybinding', ->
     beforeEach ->
       editor.setText("01\n002\n0003\n00004\n000005\n")
@@ -1606,9 +1624,11 @@ describe "Motions", ->
 
     it "selects down a line", ->
       keydown('V', shift: true)
+      expect(editor.getSelectedBufferRange().isSingleLine()).toBeFalsy()
       keydown('j')
       keydown('j')
       expect(editor.getSelectedText()).toBe "002\n0003\n00004\n"
+      expect(editor.getSelectedBufferRange().isSingleLine()).toBeFalsy()
 
     it "selects up a line", ->
       keydown('V', shift: true)

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -731,6 +731,129 @@ describe "Operators", ->
           keydown('escape')
           expect(editor.getText()).toBe("12345\n\nABCDE")
 
+    describe "in visual mode", ->
+      beforeEach ->
+        editor.setText "123456789\nabcde\nfghijklmnopq\nuvwxyz"
+        editor.setCursorScreenPosition [1, 1]
+
+      describe "with characterwise selection on a single line", ->
+        it "repeats with .", ->
+          keydown 'v'
+          keydown '2'
+          keydown 'l'
+          keydown 'c'
+          editor.insertText "ab"
+          keydown 'escape'
+          expect(editor.getText()).toBe "123456789\naabe\nfghijklmnopq\nuvwxyz"
+
+          editor.setCursorScreenPosition [0, 1]
+          keydown '.'
+          expect(editor.getText()).toBe "1ab56789\naabe\nfghijklmnopq\nuvwxyz"
+
+        it "repeats shortened with . near the end of the line", ->
+          editor.setCursorScreenPosition [0, 2]
+          keydown 'v'
+          keydown '4'
+          keydown 'l'
+          keydown 'c'
+          editor.insertText "ab"
+          keydown 'escape'
+          expect(editor.getText()).toBe "12ab89\nabcde\nfghijklmnopq\nuvwxyz"
+
+          editor.setCursorScreenPosition [1, 3]
+          keydown '.'
+          expect(editor.getText()).toBe "12ab89\nabcab\nfghijklmnopq\nuvwxyz"
+
+        it "can affect newlines when repeated with . near the end of the line with motion wrapping enabled", ->
+          atom.config.set('vim-mode.wrapLeftRightMotion', true)
+          editor.setCursorScreenPosition [0, 2]
+          keydown 'v'
+          keydown '4'
+          keydown 'l'
+          keydown 'c'
+          editor.insertText "ab"
+          keydown 'escape'
+          expect(editor.getText()).toBe "12ab89\nabcde\nfghijklmnopq\nuvwxyz"
+
+          editor.setCursorScreenPosition [1, 3]
+          keydown '.'
+          expect(editor.getText()).toBe "12ab89\nabcabhijklmnopq\nuvwxyz"
+
+      describe "is repeatable with characterwise selection over multiple lines", ->
+        it "repeats with .", ->
+          keydown 'v'
+          keydown 'j'
+          keydown '3'
+          keydown 'l'
+          keydown 'c'
+          editor.insertText "x"
+          keydown 'escape'
+          expect(editor.getText()).toBe "123456789\naxklmnopq\nuvwxyz"
+
+          editor.setCursorScreenPosition [0, 1]
+          keydown '.'
+          expect(editor.getText()).toBe "1xnopq\nuvwxyz"
+
+        it "repeats shortened with . near the end of the line", ->
+          # this behaviour is unlike VIM, see #737
+          keydown 'v'
+          keydown 'j'
+          keydown '6'
+          keydown 'l'
+          keydown 'c'
+          editor.insertText "x"
+          keydown 'escape'
+          expect(editor.getText()).toBe "123456789\naxnopq\nuvwxyz"
+
+          editor.setCursorScreenPosition [0, 1]
+          keydown '.'
+          expect(editor.getText()).toBe "1x\nuvwxyz"
+
+      describe "is repeatable with linewise selection", ->
+        describe "with one line selected", ->
+          it "repeats with .", ->
+            keydown 'V', shift: true
+            keydown 'c'
+            editor.insertText "x"
+            keydown 'escape'
+            expect(editor.getText()).toBe "123456789\nx\nfghijklmnopq\nuvwxyz"
+
+            editor.setCursorScreenPosition [0, 7]
+            keydown '.'
+            expect(editor.getText()).toBe "x\nx\nfghijklmnopq\nuvwxyz"
+
+            editor.setCursorScreenPosition [2, 0]
+            keydown '.'
+            expect(editor.getText()).toBe "x\nx\nx\nuvwxyz"
+
+        describe "with multiple lines selected", ->
+          it "repeats with .", ->
+            keydown 'V', shift: true
+            keydown 'j'
+            keydown 'c'
+            editor.insertText "x"
+            keydown 'escape'
+            expect(editor.getText()).toBe "123456789\nx\nuvwxyz"
+
+            editor.setCursorScreenPosition [0, 7]
+            keydown '.'
+            expect(editor.getText()).toBe "x\nuvwxyz"
+
+          it "repeats shortened with . near the end of the file", ->
+            keydown 'V', shift: true
+            keydown 'j'
+            keydown 'c'
+            editor.insertText "x"
+            keydown 'escape'
+            expect(editor.getText()).toBe "123456789\nx\nuvwxyz"
+
+            editor.setCursorScreenPosition [1, 7]
+            keydown '.'
+            expect(editor.getText()).toBe "123456789\nx\n"
+
+      xdescribe "is repeatable with block selection", ->
+        # there is no block selection yet
+
   describe "the C keybinding", ->
     beforeEach ->
       editor.getBuffer().setText("012\n")

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -764,7 +764,7 @@ describe "Operators", ->
           keydown '.'
           expect(editor.getText()).toBe "12ab89\nabcab\nfghijklmnopq\nuvwxyz"
 
-        it "can affect newlines when repeated with . near the end of the line with motion wrapping enabled", ->
+        it "repeats shortened with . near the end of the line regardless of whether motion wrapping is enabled", ->
           atom.config.set('vim-mode.wrapLeftRightMotion', true)
           editor.setCursorScreenPosition [0, 2]
           keydown 'v'
@@ -777,7 +777,8 @@ describe "Operators", ->
 
           editor.setCursorScreenPosition [1, 3]
           keydown '.'
-          expect(editor.getText()).toBe "12ab89\nabcabhijklmnopq\nuvwxyz"
+          # this differs from VIM, which would eat the \n before fghij...
+          expect(editor.getText()).toBe "12ab89\nabcab\nfghijklmnopq\nuvwxyz"
 
       describe "is repeatable with characterwise selection over multiple lines", ->
         it "repeats with .", ->

--- a/spec/vim-state-spec.coffee
+++ b/spec/vim-state-spec.coffee
@@ -86,12 +86,18 @@ describe "VimState", ->
         expect(editor.getCursors().length).toBe 1
 
     describe "the v keybinding", ->
-      beforeEach -> keydown('v')
+      beforeEach ->
+        editor.setText("012345\nabcdef")
+        editor.setCursorScreenPosition([0, 0])
+        keydown('v')
 
       it "puts the editor into visual characterwise mode", ->
         expect(editorElement.classList.contains('visual-mode')).toBe(true)
         expect(vimState.submode).toEqual 'characterwise'
         expect(editorElement.classList.contains('normal-mode')).toBe(false)
+
+      it "selects the current character", ->
+        expect(editor.getLastSelection().getText()).toEqual '0'
 
     describe "the V keybinding", ->
       beforeEach ->


### PR DESCRIPTION
Fixes #737.
Differs from VIM in that if the visual mode selection was characterwise over multiple lines, and the last line of the selection was longer than the corresponding line where we are redoing the operation, VIM would remove the newline and this PR doesn't. See #737 for more information on this.
Any comments will be welcome.