### PR TITLE
implement substitute using the change operator

### DIFF
--- a/lib/operators/input.coffee
+++ b/lib/operators/input.coffee
@@ -128,26 +128,6 @@ class Change extends Insert
     @vimState.activateInsertMode()
     @typingCompleted = true
 
-class Substitute extends Insert
-  register: null
-
-  constructor: (@editor, @vimState) ->
-    @register = settings.defaultRegister()
-
-  execute: (count=1) ->
-    @vimState.setInsertionCheckpoint() unless @typingCompleted
-    _.times count, =>
-      @editor.selectRight()
-    @setTextRegister(@register, @editor.getSelectedText())
-    @editor.delete()
-
-    if @typingCompleted
-      @typedText = @typedText.trimLeft()
-      return super
-
-    @vimState.activateInsertMode()
-    @typingCompleted = true
-
 class SubstituteLine extends Insert
   register: null
 
@@ -247,6 +227,5 @@ module.exports = {
   InsertBelowWithNewline,
   ReplaceMode,
   Change,
-  Substitute,
   SubstituteLine
 }

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -77,7 +77,7 @@ class VimState
     @registerOperationCommands
       'activate-insert-mode': => new Operators.Insert(@editor, this)
       'activate-replace-mode': => new Operators.ReplaceMode(@editor, this)
-      'substitute': => new Operators.Substitute(@editor, this)
+      'substitute': => [new Operators.Change(@editor, this), new Motions.MoveRight(@editor, this)]
       'substitute-line': => new Operators.SubstituteLine(@editor, this)
       'insert-after': => new Operators.InsertAfter(@editor, this)
       'insert-after-end-of-line': => new Operators.InsertAfterEndOfLine(@editor, this)


### PR DESCRIPTION
Removes some code duplication.  Counts still work of course.

There might be some other places we can do this but not sure if there's interest there is in this sort of cleanup.