### PR TITLE
cancel insert-mode ctrl-r with escape

### DIFF
--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -71,6 +71,7 @@
   'ctrl-r %': 'vim-mode:insert-mode-put'
   'ctrl-r _': 'vim-mode:insert-mode-put'
   'ctrl-r "': 'vim-mode:insert-mode-put'
+  'ctrl-r escape': 'abort!'
 
 'atom-text-editor.vim-mode:not(.insert-mode)':
   'h': 'vim-mode:move-left'

--- a/spec/prefixes-spec.coffee
+++ b/spec/prefixes-spec.coffee
@@ -173,3 +173,10 @@ describe "Prefixes", ->
         keydown 'r', ctrl: true
         keydown 'a'
         expect(editor.getText()).toBe '01abc2\n'
+
+      it "is cancelled with the escape key", ->
+        keydown 'r', ctrl: true
+        keydown 'escape'
+        expect(editor.getText()).toBe '012\n'
+        expect(vimState.mode).toBe "insert"
+        expect(editor.getCursorScreenPosition()).toEqual [0, 2]


### PR DESCRIPTION
this expands #720 with the ability to cancel a `ctrl-r` with `esc` and stay in insert mode.