### PR TITLE
cancel operator-pending on unrecognized key strokes

### DIFF
--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -1,3 +1,6 @@
+# copied from atom/atom-keymap src/helpers.coffee
+AtomModifierRegex = /(ctrl|alt|shift|cmd)$/
+
 module.exports =
   # Public: Determines if a string should be considered linewise or character
   #
@@ -12,3 +15,7 @@ module.exports =
       'linewise'
     else
       'character'
+
+  # copied and simplified from atom/atom-keymap src/helpers.coffee
+  isAtomModifier: (keystroke) ->
+    AtomModifierRegex.test(keystroke)

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -36,6 +36,12 @@ class VimState
         @activateVisualMode('characterwise') if @mode is 'command'
     , 100)
 
+    @subscriptions.add atom.keymaps.onDidFailToMatchBinding (e) =>
+      return unless e.keyboardEventTarget is @editorElement
+      if @mode is 'operator-pending'
+        atom.keymaps.cancelPendingState()
+        @resetCommandMode()
+
     @editorElement.classList.add("vim-mode")
     @setupCommandMode()
     if settings.startInInsertMode()

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -39,10 +39,15 @@ class VimState
     @subscriptions.add atom.keymaps.onDidFailToMatchBinding (e) =>
       return unless e.keyboardEventTarget is @editorElement
       return if Utils.isAtomModifier(e.keystrokes)
-      
-      atom.keymaps.cancelPendingState()
+
       if @mode is 'operator-pending'
+        atom.keymaps.cancelPendingState()
+        atom.beep()
         @resetCommandMode()
+
+      if @mode is 'visual'
+        atom.keymaps.cancelPendingState()
+        atom.beep()
 
     @editorElement.classList.add("vim-mode")
     @setupCommandMode()

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -38,8 +38,8 @@ class VimState
 
     @subscriptions.add atom.keymaps.onDidFailToMatchBinding (e) =>
       return unless e.keyboardEventTarget is @editorElement
+      atom.keymaps.cancelPendingState()
       if @mode is 'operator-pending'
-        atom.keymaps.cancelPendingState()
         @resetCommandMode()
 
     @editorElement.classList.add("vim-mode")

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -38,7 +38,7 @@ class VimState
 
     @subscriptions.add atom.keymaps.onDidFailToMatchBinding (e) =>
       return unless e.keyboardEventTarget is @editorElement
-      return if Utils.isAtomModifier(e.keystrokes)
+      return if e.keystrokes.indexOf(' ') >= 0 or Utils.isAtomModifier(e.keystrokes)
 
       if @mode is 'operator-pending'
         atom.keymaps.cancelPendingState()

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -38,6 +38,8 @@ class VimState
 
     @subscriptions.add atom.keymaps.onDidFailToMatchBinding (e) =>
       return unless e.keyboardEventTarget is @editorElement
+      return if Utils.isAtomModifier(e.keystrokes)
+      
       atom.keymaps.cancelPendingState()
       if @mode is 'operator-pending'
         @resetCommandMode()

--- a/spec/vim-state-spec.coffee
+++ b/spec/vim-state-spec.coffee
@@ -424,19 +424,33 @@ describe "VimState", ->
       editor.setText "line one\n line two\n"
       editor.setCursorBufferPosition [0, 0]
 
-    it "cancels short pending operations on unrecognized keybinding", ->
-      keydown 'c'
-      keydown 'q' #cq doesn't work, should cancel
-      keydown 'w'
-      expect(editor.getCursorBufferPosition()).toEqual [0, 5]
-      expect(editor.getText()).toBe "line one\n line two\n"
-      expect(vimState.mode).toEqual 'command'
+    describe "in operator-pending mode", ->
+      beforeEach ->
+        keydown 'c'
 
-    it "cancels long pending operations on unrecognized keybinding", ->
-      keydown 'c'
-      keydown 'i'
-      keydown '3' #i3 is unrecognized, should cancel the whole `ci3` sequence
-      keydown 'w'
-      expect(editor.getCursorBufferPosition()).toEqual [0, 5]
-      expect(editor.getText()).toBe "line one\n line two\n"
-      expect(vimState.mode).toEqual 'command'
+      it "cancels short pending operations on unrecognized keybinding", ->
+        keydown 'q' #cq doesn't work, should cancel
+        keydown 'w'
+        expect(editor.getCursorBufferPosition()).toEqual [0, 5]
+        expect(editor.getText()).toBe "line one\n line two\n"
+        expect(vimState.mode).toEqual 'command'
+
+      it "cancels long pending operations on unrecognized keybinding", ->
+        keydown 'i'
+        keydown '3' #i3 is unrecognized, should cancel the whole `ci3` sequence
+        keydown 'w'
+        expect(editor.getCursorBufferPosition()).toEqual [0, 5]
+        expect(editor.getText()).toBe "line one\n line two\n"
+        expect(vimState.mode).toEqual 'command'
+
+    describe "in visual mode", ->
+      beforeEach ->
+        keydown 'v'
+
+      it "cancels whole unrecognized keybinding", ->
+        keydown 'i'
+        keydown '3' #i3 is unrecognized, should cancel the whole `i3` sequence
+        keydown 'w'
+        expect(editor.getCursorBufferPosition()).toEqual [0, 6]
+        expect(editor.getSelectedText()).toBe "line o"
+        expect(vimState.mode).toEqual 'visual'

--- a/spec/vim-state-spec.coffee
+++ b/spec/vim-state-spec.coffee
@@ -418,3 +418,25 @@ describe "VimState", ->
       keydown('`')
       commandModeInputKeydown('q')
       expect(editor.getCursorScreenPosition()).toEqual [1, 2]
+
+  describe "unknown key bindings", ->
+    beforeEach ->
+      editor.setText "line one\n line two\n"
+      editor.setCursorBufferPosition [0, 0]
+
+    it "cancels short pending operations on unrecognized keybinding", ->
+      keydown 'c'
+      keydown 'q' #cq doesn't work, should cancel
+      keydown 'w'
+      expect(editor.getCursorBufferPosition()).toEqual [0, 5]
+      expect(editor.getText()).toBe "line one\n line two\n"
+      expect(vimState.mode).toEqual 'command'
+
+    it "cancels long pending operations on unrecognized keybinding", ->
+      keydown 'c'
+      keydown 'i'
+      keydown '3' #i3 is unrecognized, should cancel the whole `ci3` sequence
+      keydown 'w'
+      expect(editor.getCursorBufferPosition()).toEqual [0, 5]
+      expect(editor.getText()).toBe "line one\n line two\n"
+      expect(vimState.mode).toEqual 'command'


### PR DESCRIPTION
_(edited)_ Fix #734 and #680. This is an alternative to #781, because of issues noted below in https://github.com/atom/vim-mode/pull/764#issuecomment-122441219 and further comments. Discussion welcome. 

This fix overrides Atom's normal key binding resolution process for multi-keystroke key bindings: where Atom will do `ci3w` like this:
1. `c` -> change
2. `i` -> _some potential bindings, e.g. `iw`, `ip` etc., so let's wait_
3. `3` -> `i3` is not known and no key binding starts with `i3` so let's break it down
   1. `i` on its own is unknown in operator-pending mode, so let's ignore it
   2. let's try again `3` -> a prefix, good
4. `w` combines with `3` so the final result is `c3w` 

What we want is
1. `c` -> change
2. `i` as above
3. `3` leads to `i3` which is unknown and cancels `c`
4. `w` moves cursor to next word

We could beep on a cancellation like this.

The `atom.keymaps.cancelPendingState()` call is a private API, but I can't judge whether that's too bad for this PR.
