### PR TITLE
repeating without search history should do nothing

### DIFF
--- a/lib/motions/search-motion.coffee
+++ b/lib/motions/search-motion.coffee
@@ -27,6 +27,8 @@ class SearchBase extends MotionWithInput
       atom.beep()
 
   scan: (cursor) ->
+    return [] if @input.characters is ""
+
     currentPosition = cursor.getBufferPosition()
 
     [rangesBefore, rangesAfter] = [[], []]

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -997,6 +997,10 @@ describe "Motions", ->
       editor.setText("abc\ndef\nabc\ndef\n")
       editor.setCursorBufferPosition([0, 0])
 
+      # clear search history
+      vimState.globalVimState.searchHistory = []
+      vimState.globalVimState.currentSearch = {}
+
     describe "as a motion", ->
       it "moves the cursor to the specified search pattern", ->
         keydown('/')
@@ -1100,9 +1104,14 @@ describe "Motions", ->
 
       describe "repeating", ->
         it "does nothing with no search history", ->
-          # This tests that no exception is raised
+          editor.setCursorBufferPosition([0, 0])
           keydown('n')
+          expect(editor.getCursorBufferPosition()).toEqual [0, 0]
+          editor.setCursorBufferPosition([1, 1])
+          keydown('n')
+          expect(editor.getCursorBufferPosition()).toEqual [1, 1]
 
+      describe "repeating with search history", ->
         beforeEach ->
           keydown('/')
           submitCommandModeInputText 'def'


### PR DESCRIPTION
When Atom starts, there is no search history, and `n` would advance by a character because it searches for nothing, which matches everywhere.
This PR fixes that.