### PR TITLE
fix: isLinewise shouldn't be required

### DIFF
--- a/lib/prefixes.coffee
+++ b/lib/prefixes.coffee
@@ -27,7 +27,7 @@ class Prefix
     @composedObject.select?(@count)
 
   isLinewise: ->
-    @composedObject.isLinewise()
+    @composedObject.isLinewise?()
 
 #
 # Used to track the number of times either a motion or operator should


### PR DESCRIPTION
This PR addresses the issue that generated an exception in #760 and #741. It doesn't add counts to text objects, that can be another PR; but at least vim-mode doesn't crash anymore on `c3aw`.
We might close #760 and #741 and open an issue that text objects don't have counts.