### PR TITLE
harmonize selection directions (reversion) on `o`

### DIFF
--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -550,8 +550,8 @@ class VimState
         @pushOperations(new Prefixes.Repeat(num))
 
   reverseSelections: ->
+    reversed = not @editor.getLastSelection().isReversed()
     for selection in @editor.getSelections()
-      reversed = not selection.isReversed()
       selection.setBufferRange(selection.getBufferRange(), {reversed})
 
   # Private: Figure out whether or not we are in a repeat sequence or we just

--- a/spec/vim-state-spec.coffee
+++ b/spec/vim-state-spec.coffee
@@ -302,6 +302,32 @@ describe "VimState", ->
           [0, 8]
         ])
 
+      it "harmonizes selection directions", ->
+        keydown("i")
+        keydown("w")
+        editor.addCursorAtBufferPosition([0, Infinity])
+        keydown("h")
+
+        expect(editor.getSelectedBufferRanges()).toEqual([
+          [[0, 4], [0, 6]],
+          [[0, 12], [0, 13]]
+        ])
+        expect(editor.getCursorBufferPositions()).toEqual([
+          [0, 6]
+          [0, 12]
+        ])
+
+        keydown("o")
+
+        expect(editor.getSelectedBufferRanges()).toEqual([
+          [[0, 4], [0, 6]],
+          [[0, 12], [0, 13]]
+        ])
+        expect(editor.getCursorBufferPositions()).toEqual([
+          [0, 6]
+          [0, 13]
+        ])
+
     describe "activate visualmode witin visualmode", ->
       beforeEach ->
         keydown('escape')


### PR DESCRIPTION
When working with multiple selections, one may end up with selections with different directions. This PR changes the behaviour of the `o` command to harmonize selection directions. I believe this will be helpful; discussion welcome.