### PR TITLE
Add subword movement support

### DIFF
--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -90,6 +90,7 @@
   'e': 'vim-mode:move-to-end-of-word'
   'E': 'vim-mode:move-to-end-of-whole-word'
   'b': 'vim-mode:move-to-previous-word'
+  'alt-b': 'vim-mode:move-to-previous-alt-word'
   'B': 'vim-mode:move-to-previous-whole-word'
   '}': 'vim-mode:move-to-next-paragraph'
   '{': 'vim-mode:move-to-previous-paragraph'

--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -85,6 +85,7 @@
   'down': 'vim-mode:move-down'
 
   'w': 'vim-mode:move-to-next-word'
+  'alt-w': 'vim-mode:move-to-next-alt-word'
   'W': 'vim-mode:move-to-next-whole-word'
   'e': 'vim-mode:move-to-end-of-word'
   'E': 'vim-mode:move-to-end-of-whole-word'

--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -218,7 +218,8 @@ class MoveToNextWord extends Motion
 
   moveCursorToNextSubword: (cursor, count, options) ->
     @subwordRegex ?= cursor.subwordRegExp()
-    @moveCursorByRegex(cursor, count, options, @subwordRegex)
+    # HACK: expected behavior got changed with https://github.com/atom/atom/commit/ba3ab41
+    @moveCursorByRegex(cursor, count, options, new RegExp("^[\t ]*$|"+@subwordRegex.source.substring(14), "g"))
 
   moveCursorByRegex: (cursor, count, options, wordRegex) ->
     _.times count, =>

--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -190,6 +190,7 @@ class MoveToPreviousWord extends Motion
 
   moveCursorToPreviousSubword: (cursor, count) ->
     _.times count, ->
+      # XXX: Doesn't actually work as it also moves to the ending of the previous subword
       cursor.moveToPreviousSubwordBoundary()
 
   moveCursorToPreviousWord: (cursor, count) ->

--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -183,8 +183,25 @@ class MoveToPreviousWord extends Motion
   operatesInclusively: false
 
   moveCursor: (cursor, count=1) ->
+    if settings.defaultWordIsCamelCaseSensitive()
+      @moveCursorToPreviousSubword(cursor, count)
+    else
+      @moveCursorToPreviousWord(cursor, count)
+
+  moveCursorToPreviousSubword: (cursor, count) ->
+    _.times count, ->
+      cursor.moveToPreviousSubwordBoundary()
+
+  moveCursorToPreviousWord: (cursor, count) ->
     _.times count, ->
       cursor.moveToBeginningOfWord()
+
+class MoveToPreviousAltWord extends MoveToPreviousWord
+  moveCursor: (cursor, count=1) ->
+    if settings.defaultWordIsCamelCaseSensitive()
+      @moveCursorToPreviousWord(cursor, count)
+    else
+      @moveCursorToPreviousSubword(cursor, count)
 
 class MoveToPreviousWholeWord extends Motion
   operatesInclusively: false
@@ -477,7 +494,7 @@ class ScrollFullDownKeepCursor extends ScrollKeepingCursor
 
 module.exports = {
   Motion, MotionWithInput, CurrentSelection, MoveLeft, MoveRight, MoveUp, MoveDown,
-  MoveToPreviousWord, MoveToPreviousWholeWord, MoveToNextWord, MoveToNextWholeWord, MoveToNextAltWord,
+  MoveToPreviousWord, MoveToPreviousAltWord, MoveToPreviousWholeWord, MoveToNextWord, MoveToNextWholeWord, MoveToNextAltWord,
   MoveToEndOfWord, MoveToNextParagraph, MoveToPreviousParagraph, MoveToAbsoluteLine, MoveToRelativeLine, MoveToBeginningOfLine,
   MoveToFirstCharacterOfLineUp, MoveToFirstCharacterOfLineDown,
   MoveToFirstCharacterOfLine, MoveToFirstCharacterOfLineAndDown, MoveToLastCharacterOfLine,

--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -263,16 +263,16 @@ class MoveToNextWord extends Motion
     eof = @editor.getEofBufferPosition()
     cur.row is eof.row and cur.column is eof.column
 
-class MoveToNextWholeWord extends MoveToNextWord
-  moveCursor: (cursor, count=1, options) ->
-    @moveCursorByRegex(cursor, count, options, WholeWordOrEmptyLineRegex)
-
 class MoveToNextAltWord extends MoveToNextWord
   moveCursor: (cursor, count=1, options) ->
     if settings.defaultWordIsCamelCaseSensitive()
       @moveCursorToNextWord(cursor, count, options)
     else
       @moveCursorToNextSubword(cursor, count, options)
+
+class MoveToNextWholeWord extends MoveToNextWord
+  moveCursor: (cursor, count=1, options) ->
+    @moveCursorByRegex(cursor, count, options, WholeWordOrEmptyLineRegex)
 
 class MoveToEndOfWord extends Motion
   wordRegex: null
@@ -494,7 +494,7 @@ class ScrollFullDownKeepCursor extends ScrollKeepingCursor
 
 module.exports = {
   Motion, MotionWithInput, CurrentSelection, MoveLeft, MoveRight, MoveUp, MoveDown,
-  MoveToPreviousWord, MoveToPreviousAltWord, MoveToPreviousWholeWord, MoveToNextWord, MoveToNextWholeWord, MoveToNextAltWord,
+  MoveToPreviousWord, MoveToPreviousAltWord, MoveToPreviousWholeWord, MoveToNextWord, MoveToNextAltWord, MoveToNextWholeWord,
   MoveToEndOfWord, MoveToNextParagraph, MoveToPreviousParagraph, MoveToAbsoluteLine, MoveToRelativeLine, MoveToBeginningOfLine,
   MoveToFirstCharacterOfLineUp, MoveToFirstCharacterOfLineDown,
   MoveToFirstCharacterOfLine, MoveToFirstCharacterOfLineAndDown, MoveToLastCharacterOfLine,

--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -204,17 +204,30 @@ class MoveToPreviousWholeWord extends Motion
     not cur.row and not cur.column
 
 class MoveToNextWord extends Motion
-  wordRegex: null
+  subwordRegex: null
   operatesInclusively: false
 
   moveCursor: (cursor, count=1, options) ->
+    if settings.defaultWordIsCamelCaseSensitive()
+      @moveCursorToNextSubword(cursor, count, options)
+    else
+      @moveCursorToNextWord(cursor, count, options)
+
+  moveCursorToNextWord: (cursor, count, options) ->
+    @moveCursorByRegex(cursor, count, options, null)
+
+  moveCursorToNextSubword: (cursor, count, options) ->
+    @subwordRegex ?= cursor.subwordRegExp()
+    @moveCursorByRegex(cursor, count, options, @subwordRegex)
+
+  moveCursorByRegex: (cursor, count, options, wordRegex) ->
     _.times count, =>
       current = cursor.getBufferPosition()
 
       next = if options?.excludeWhitespace
-        cursor.getEndOfCurrentWordBufferPosition(wordRegex: @wordRegex)
+        cursor.getEndOfCurrentWordBufferPosition(wordRegex: wordRegex)
       else
-        cursor.getBeginningOfNextWordBufferPosition(wordRegex: @wordRegex)
+        cursor.getBeginningOfNextWordBufferPosition(wordRegex: wordRegex)
 
       return if @isEndOfFile(cursor)
 
@@ -233,7 +246,15 @@ class MoveToNextWord extends Motion
     cur.row is eof.row and cur.column is eof.column
 
 class MoveToNextWholeWord extends MoveToNextWord
-  wordRegex: WholeWordOrEmptyLineRegex
+  moveCursor: (cursor, count=1, options) ->
+    @moveCursorByRegex(cursor, count, options, WholeWordOrEmptyLineRegex)
+
+class MoveToNextAltWord extends MoveToNextWord
+  moveCursor: (cursor, count=1, options) ->
+    if settings.defaultWordIsCamelCaseSensitive()
+      @moveCursorToNextWord(cursor, count, options)
+    else
+      @moveCursorToNextSubword(cursor, count, options)
 
 class MoveToEndOfWord extends Motion
   wordRegex: null
@@ -455,7 +476,7 @@ class ScrollFullDownKeepCursor extends ScrollKeepingCursor
 
 module.exports = {
   Motion, MotionWithInput, CurrentSelection, MoveLeft, MoveRight, MoveUp, MoveDown,
-  MoveToPreviousWord, MoveToPreviousWholeWord, MoveToNextWord, MoveToNextWholeWord,
+  MoveToPreviousWord, MoveToPreviousWholeWord, MoveToNextWord, MoveToNextWholeWord, MoveToNextAltWord,
   MoveToEndOfWord, MoveToNextParagraph, MoveToPreviousParagraph, MoveToAbsoluteLine, MoveToRelativeLine, MoveToBeginningOfLine,
   MoveToFirstCharacterOfLineUp, MoveToFirstCharacterOfLineDown,
   MoveToFirstCharacterOfLine, MoveToFirstCharacterOfLineAndDown, MoveToLastCharacterOfLine,

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -17,7 +17,7 @@ settings =
       type: 'string'
       default: '-?[0-9]+'
       description: 'Use this to control how Ctrl-A/Ctrl-X finds numbers; use "(?:\\B-)?[0-9]+" to treat numbers as positive if the minus is preceded by a character, e.g. in "identifier-1".'
-    makeDefaultWordCamelCaseSensitive:
+    defaultWordIsCamelCaseSensitive:
       type: 'boolean'
       default: true
       description: 'If set to true, the w and similar motions and text objects will be camel-case sensitive. The alt modifier key can be used to access the camel-case insensitive behaviour. Setting to false reverses the bindings.'

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -17,6 +17,10 @@ settings =
       type: 'string'
       default: '-?[0-9]+'
       description: 'Use this to control how Ctrl-A/Ctrl-X finds numbers; use "(?:\\B-)?[0-9]+" to treat numbers as positive if the minus is preceded by a character, e.g. in "identifier-1".'
+    makeDefaultWordCamelCaseSensitive:
+      type: 'boolean'
+      default: true
+      description: 'If set to true, the w and similar motions and text objects will be camel-case sensitive. The alt modifier key can be used to access the camel-case insensitive behaviour. Setting to false reverses the bindings.'
 
 Object.keys(settings.config).forEach (k) ->
   settings[k] = ->

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -110,6 +110,7 @@ class VimState
       'move-to-end-of-word': => new Motions.MoveToEndOfWord(@editor, this)
       'move-to-end-of-whole-word': => new Motions.MoveToEndOfWholeWord(@editor, this)
       'move-to-previous-word': => new Motions.MoveToPreviousWord(@editor, this)
+      'move-to-previous-alt-word': => new Motions.MoveToPreviousAltWord(@editor, this)
       'move-to-previous-whole-word': => new Motions.MoveToPreviousWholeWord(@editor, this)
       'move-to-next-paragraph': => new Motions.MoveToNextParagraph(@editor, this)
       'move-to-previous-paragraph': => new Motions.MoveToPreviousParagraph(@editor, this)

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -105,6 +105,7 @@ class VimState
       'move-down': => new Motions.MoveDown(@editor, this)
       'move-right': => new Motions.MoveRight(@editor, this)
       'move-to-next-word': => new Motions.MoveToNextWord(@editor, this)
+      'move-to-next-alt-word': => new Motions.MoveToNextAltWord(@editor, this)
       'move-to-next-whole-word': => new Motions.MoveToNextWholeWord(@editor, this)
       'move-to-end-of-word': => new Motions.MoveToEndOfWord(@editor, this)
       'move-to-end-of-whole-word': => new Motions.MoveToEndOfWholeWord(@editor, this)

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -125,59 +125,67 @@ describe "Motions", ->
           keydown('l')
           expect(editor.getCursorBufferPosition()).toEqual [1, 0]
 
-  describe "the w keybinding", ->
-    beforeEach -> editor.setText("ab cde1+- \n xyz\n\nzip")
+  describe "the w and alt-w keybindings", ->
+    itMovesByWord = (key) ->
+      describe "moving by word", ->
+        beforeEach -> editor.setText("ab cDeFg1+- \n xyz\n\nzip")
 
-    describe "as a motion", ->
-      beforeEach -> editor.setCursorScreenPosition([0, 0])
+        describe "as a motion", ->
+          beforeEach -> editor.setCursorScreenPosition([0, 0])
 
-      it "moves the cursor to the beginning of the next word", ->
-        keydown('w')
-        expect(editor.getCursorScreenPosition()).toEqual [0, 3]
+          it "moves the cursor to the beginning of the next word", ->
+            keydown(key)
+            expect(editor.getCursorScreenPosition()).toEqual [0, 3]
 
-        keydown('w')
-        expect(editor.getCursorScreenPosition()).toEqual [0, 7]
+            keydown(key)
+            expect(editor.getCursorScreenPosition()).toEqual [0, 9]
 
-        keydown('w')
-        expect(editor.getCursorScreenPosition()).toEqual [1, 1]
+            keydown(key)
+            expect(editor.getCursorScreenPosition()).toEqual [1, 1]
 
-        keydown('w')
-        expect(editor.getCursorScreenPosition()).toEqual [2, 0]
+            keydown(key)
+            expect(editor.getCursorScreenPosition()).toEqual [2, 0]
 
-        keydown('w')
-        expect(editor.getCursorScreenPosition()).toEqual [3, 0]
+            keydown(key)
+            expect(editor.getCursorScreenPosition()).toEqual [3, 0]
 
-        keydown('w')
-        expect(editor.getCursorScreenPosition()).toEqual [3, 3]
+            keydown(key)
+            expect(editor.getCursorScreenPosition()).toEqual [3, 3]
 
-        # After cursor gets to the EOF, it should stay there.
-        keydown('w')
-        expect(editor.getCursorScreenPosition()).toEqual [3, 3]
+            # After cursor gets to the EOF, it should stay there.
+            keydown(key)
+            expect(editor.getCursorScreenPosition()).toEqual [3, 3]
 
-      it "moves the cursor to the end of the word if last word in file", ->
-        editor.setText("abc")
-        editor.setCursorScreenPosition([0, 0])
-        keydown('w')
-        expect(editor.getCursorScreenPosition()).toEqual([0, 3])
+          it "moves the cursor to the end of the word if last word in file", ->
+            editor.setText("abc")
+            editor.setCursorScreenPosition([0, 0])
+            keydown(key)
+            expect(editor.getCursorScreenPosition()).toEqual([0, 3])
 
-    describe "as a selection", ->
-      describe "within a word", ->
-        beforeEach ->
-          editor.setCursorScreenPosition([0, 0])
-          keydown('y')
-          keydown('w')
+        describe "as a selection", ->
+          describe "within a word", ->
+            beforeEach ->
+              editor.setCursorScreenPosition([0, 0])
+              keydown('y')
+              keydown(key)
 
-        it "selects to the end of the word", ->
-          expect(vimState.getRegister('"').text).toBe 'ab '
+            it "selects to the end of the word", ->
+              expect(vimState.getRegister('"').text).toBe 'ab '
 
-      describe "between words", ->
-        beforeEach ->
-          editor.setCursorScreenPosition([0, 2])
-          keydown('y')
-          keydown('w')
+          describe "between words", ->
+            beforeEach ->
+              editor.setCursorScreenPosition([0, 2])
+              keydown('y')
+              keydown(key)
 
-        it "selects the whitespace", ->
-          expect(vimState.getRegister('"').text).toBe ' '
+            it "selects the whitespace", ->
+              expect(vimState.getRegister('"').text).toBe ' '
+
+    describe "the w keybinding", ->
+      describe "with it configured to be camel-case insensitive", ->
+        beforeEach -> atom.config.set('vim-mode.defaultWordIsCamelCaseSensitive', false)
+
+        itMovesByWord('w')
 
   describe "the W keybinding", ->
     beforeEach -> editor.setText("cde1+- ab \n xyz\n\nzip")

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -128,7 +128,7 @@ describe "Motions", ->
   describe "the w and alt-w keybindings", ->
     itMovesByWord = (key, options) ->
       describe "moving by word", ->
-        beforeEach -> editor.setText("ab cDeFg1+- \n xyz\n\nzip")
+        beforeEach -> editor.setText("ab = cDeFg1+- \n xyz\n\nzip")
 
         describe "as a motion", ->
           beforeEach -> editor.setCursorScreenPosition([0, 0])
@@ -138,7 +138,10 @@ describe "Motions", ->
             expect(editor.getCursorScreenPosition()).toEqual [0, 3]
 
             keydown(key, options)
-            expect(editor.getCursorScreenPosition()).toEqual [0, 9]
+            expect(editor.getCursorScreenPosition()).toEqual [0, 5]
+
+            keydown(key, options)
+            expect(editor.getCursorScreenPosition()).toEqual [0, 11]
 
             keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [1, 1]
@@ -165,7 +168,7 @@ describe "Motions", ->
         describe "as a selection", ->
           describe "within a word", ->
             beforeEach ->
-              editor.setCursorScreenPosition([0, 3])
+              editor.setCursorScreenPosition([0, 5])
               keydown('y')
               keydown(key, options)
 
@@ -183,7 +186,7 @@ describe "Motions", ->
 
     itMovesBySubword = (key, options) ->
       describe "moving by subword", ->
-        beforeEach -> editor.setText("ab cDeFg1+- \n xyz\n\nzip")
+        beforeEach -> editor.setText("ab = cDeFg1+- \n xyz\n\nzip")
 
         describe "as a motion", ->
           beforeEach -> editor.setCursorScreenPosition([0, 0])
@@ -193,7 +196,7 @@ describe "Motions", ->
             expect(editor.getCursorScreenPosition()).toEqual [0, 3]
 
             keydown(key, options)
-            expect(editor.getCursorScreenPosition()).toEqual [0, 4]
+            expect(editor.getCursorScreenPosition()).toEqual [0, 5]
 
             keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [0, 6]
@@ -202,7 +205,10 @@ describe "Motions", ->
             expect(editor.getCursorScreenPosition()).toEqual [0, 8]
 
             keydown(key, options)
-            expect(editor.getCursorScreenPosition()).toEqual [0, 9]
+            expect(editor.getCursorScreenPosition()).toEqual [0, 10]
+
+            keydown(key, options)
+            expect(editor.getCursorScreenPosition()).toEqual [0, 11]
 
             keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [1, 1]
@@ -229,7 +235,7 @@ describe "Motions", ->
         describe "as a selection", ->
           describe "within a word", ->
             beforeEach ->
-              editor.setCursorScreenPosition([0, 3])
+              editor.setCursorScreenPosition([0, 5])
               keydown('y')
               keydown(key, options)
 
@@ -238,7 +244,7 @@ describe "Motions", ->
 
           describe "between words", ->
             beforeEach ->
-              editor.setCursorScreenPosition([0, 2])
+              editor.setCursorScreenPosition([0, 4])
               keydown('y')
               keydown(key, options)
 

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -125,7 +125,7 @@ describe "Motions", ->
           keydown('l')
           expect(editor.getCursorBufferPosition()).toEqual [1, 0]
 
-  describe "the w and alt-w keybindings", ->
+  fdescribe "the w and alt-w keybindings", ->
     itMovesByWord = (key) ->
       describe "moving by word", ->
         beforeEach -> editor.setText("ab cDeFg1+- \n xyz\n\nzip")
@@ -187,7 +187,7 @@ describe "Motions", ->
 
         itMovesByWord('w')
 
-  describe "the W keybinding", ->
+  fdescribe "the W keybinding", ->
     beforeEach -> editor.setText("cde1+- ab \n xyz\n\nzip")
 
     describe "as a motion", ->

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -165,12 +165,12 @@ describe "Motions", ->
         describe "as a selection", ->
           describe "within a word", ->
             beforeEach ->
-              editor.setCursorScreenPosition([0, 0])
+              editor.setCursorScreenPosition([0, 3])
               keydown('y')
               keydown(key)
 
-            it "selects to the end of the word", ->
-              expect(vimState.getRegister('"').text).toBe 'ab '
+            it "selects to the beginning of the next word", ->
+              expect(vimState.getRegister('"').text).toBe 'cDeFg1'
 
           describe "between words", ->
             beforeEach ->

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -126,7 +126,7 @@ describe "Motions", ->
           expect(editor.getCursorBufferPosition()).toEqual [1, 0]
 
   fdescribe "the w and alt-w keybindings", ->
-    itMovesByWord = (key) ->
+    itMovesByWord = (key, options) ->
       describe "moving by word", ->
         beforeEach -> editor.setText("ab cDeFg1+- \n xyz\n\nzip")
 
@@ -134,32 +134,32 @@ describe "Motions", ->
           beforeEach -> editor.setCursorScreenPosition([0, 0])
 
           it "moves the cursor to the beginning of the next word", ->
-            keydown(key)
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [0, 3]
 
-            keydown(key)
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [0, 9]
 
-            keydown(key)
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [1, 1]
 
-            keydown(key)
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [2, 0]
 
-            keydown(key)
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [3, 0]
 
-            keydown(key)
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [3, 3]
 
             # After cursor gets to the EOF, it should stay there.
-            keydown(key)
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [3, 3]
 
           it "moves the cursor to the end of the word if last word in file", ->
             editor.setText("abc")
             editor.setCursorScreenPosition([0, 0])
-            keydown(key)
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual([0, 3])
 
         describe "as a selection", ->
@@ -167,7 +167,7 @@ describe "Motions", ->
             beforeEach ->
               editor.setCursorScreenPosition([0, 3])
               keydown('y')
-              keydown(key)
+              keydown(key, options)
 
             it "selects to the beginning of the next word", ->
               expect(vimState.getRegister('"').text).toBe 'cDeFg1'
@@ -176,12 +176,12 @@ describe "Motions", ->
             beforeEach ->
               editor.setCursorScreenPosition([0, 2])
               keydown('y')
-              keydown(key)
+              keydown(key, options)
 
             it "selects the whitespace", ->
               expect(vimState.getRegister('"').text).toBe ' '
 
-    itMovesBySubword = (key) ->
+    itMovesBySubword = (key, options) ->
       describe "moving by subword", ->
         beforeEach -> editor.setText("ab cDeFg1+- \n xyz\n\nzip")
 
@@ -189,41 +189,41 @@ describe "Motions", ->
           beforeEach -> editor.setCursorScreenPosition([0, 0])
 
           it "moves the cursor to the beginning of the next subword", ->
-            keydown(key)
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [0, 3]
 
-            keydown(key)
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [0, 4]
 
-            keydown(key)
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [0, 6]
 
-            keydown(key)
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [0, 8]
 
-            keydown(key)
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [0, 9]
 
-            keydown(key)
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [1, 1]
 
-            keydown(key)
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [2, 0]
 
-            keydown(key)
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [3, 0]
 
-            keydown(key)
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [3, 3]
 
             # After cursor gets to the EOF, it should stay there.
-            keydown(key)
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [3, 3]
 
           it "moves the cursor to the end of the word if last word in file", ->
             editor.setText("abc")
             editor.setCursorScreenPosition([0, 0])
-            keydown(key)
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual([0, 3])
 
         describe "as a selection", ->
@@ -231,7 +231,7 @@ describe "Motions", ->
             beforeEach ->
               editor.setCursorScreenPosition([0, 3])
               keydown('y')
-              keydown(key)
+              keydown(key, options)
 
             it "selects to the beginning of the next word", ->
               expect(vimState.getRegister('"').text).toBe 'c'
@@ -240,7 +240,7 @@ describe "Motions", ->
             beforeEach ->
               editor.setCursorScreenPosition([0, 2])
               keydown('y')
-              keydown(key)
+              keydown(key, options)
 
             it "selects the whitespace", ->
               expect(vimState.getRegister('"').text).toBe ' '
@@ -255,6 +255,17 @@ describe "Motions", ->
         beforeEach -> atom.config.set('vim-mode.defaultWordIsCamelCaseSensitive', true)
 
         itMovesBySubword('w')
+
+    describe "the alt-w keybinding", ->
+      describe "with it configured to be camel-case insensitive", ->
+        beforeEach -> atom.config.set('vim-mode.defaultWordIsCamelCaseSensitive', true)
+
+        itMovesByWord('w', alt: true)
+
+      describe "with it configured to be camel-case sensitive", ->
+        beforeEach -> atom.config.set('vim-mode.defaultWordIsCamelCaseSensitive', false)
+
+        itMovesBySubword('w', alt: true)
 
   fdescribe "the W keybinding", ->
     beforeEach -> editor.setText("cde1+- ab \n xyz\n\nzip")

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -181,11 +181,80 @@ describe "Motions", ->
             it "selects the whitespace", ->
               expect(vimState.getRegister('"').text).toBe ' '
 
+    itMovesBySubword = (key) ->
+      describe "moving by subword", ->
+        beforeEach -> editor.setText("ab cDeFg1+- \n xyz\n\nzip")
+
+        describe "as a motion", ->
+          beforeEach -> editor.setCursorScreenPosition([0, 0])
+
+          it "moves the cursor to the beginning of the next subword", ->
+            keydown(key)
+            expect(editor.getCursorScreenPosition()).toEqual [0, 3]
+
+            keydown(key)
+            expect(editor.getCursorScreenPosition()).toEqual [0, 4]
+
+            keydown(key)
+            expect(editor.getCursorScreenPosition()).toEqual [0, 6]
+
+            keydown(key)
+            expect(editor.getCursorScreenPosition()).toEqual [0, 8]
+
+            keydown(key)
+            expect(editor.getCursorScreenPosition()).toEqual [0, 9]
+
+            keydown(key)
+            expect(editor.getCursorScreenPosition()).toEqual [1, 1]
+
+            keydown(key)
+            expect(editor.getCursorScreenPosition()).toEqual [2, 0]
+
+            keydown(key)
+            expect(editor.getCursorScreenPosition()).toEqual [3, 0]
+
+            keydown(key)
+            expect(editor.getCursorScreenPosition()).toEqual [3, 3]
+
+            # After cursor gets to the EOF, it should stay there.
+            keydown(key)
+            expect(editor.getCursorScreenPosition()).toEqual [3, 3]
+
+          it "moves the cursor to the end of the word if last word in file", ->
+            editor.setText("abc")
+            editor.setCursorScreenPosition([0, 0])
+            keydown(key)
+            expect(editor.getCursorScreenPosition()).toEqual([0, 3])
+
+        describe "as a selection", ->
+          describe "within a word", ->
+            beforeEach ->
+              editor.setCursorScreenPosition([0, 3])
+              keydown('y')
+              keydown(key)
+
+            it "selects to the beginning of the next word", ->
+              expect(vimState.getRegister('"').text).toBe 'c'
+
+          describe "between words", ->
+            beforeEach ->
+              editor.setCursorScreenPosition([0, 2])
+              keydown('y')
+              keydown(key)
+
+            it "selects the whitespace", ->
+              expect(vimState.getRegister('"').text).toBe ' '
+
     describe "the w keybinding", ->
       describe "with it configured to be camel-case insensitive", ->
         beforeEach -> atom.config.set('vim-mode.defaultWordIsCamelCaseSensitive', false)
 
         itMovesByWord('w')
+
+      describe "with it configured to be camel-case sensitive", ->
+        beforeEach -> atom.config.set('vim-mode.defaultWordIsCamelCaseSensitive', true)
+
+        itMovesBySubword('w')
 
   fdescribe "the W keybinding", ->
     beforeEach -> editor.setText("cde1+- ab \n xyz\n\nzip")

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -125,7 +125,7 @@ describe "Motions", ->
           keydown('l')
           expect(editor.getCursorBufferPosition()).toEqual [1, 0]
 
-  fdescribe "the w and alt-w keybindings", ->
+  describe "the w and alt-w keybindings", ->
     itMovesByWord = (key, options) ->
       describe "moving by word", ->
         beforeEach -> editor.setText("ab cDeFg1+- \n xyz\n\nzip")
@@ -267,7 +267,7 @@ describe "Motions", ->
 
         itMovesBySubword('w', alt: true)
 
-  fdescribe "the W keybinding", ->
+  describe "the W keybinding", ->
     beforeEach -> editor.setText("cde1+- ab \n xyz\n\nzip")
 
     describe "as a motion", ->

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -607,6 +607,17 @@ describe "Motions", ->
 
         itMovesBySubword('b')
 
+    describe "the alt-b keybinding", ->
+      describe "with it configured to be camel-case insensitive", ->
+        beforeEach -> atom.config.set('vim-mode.defaultWordIsCamelCaseSensitive', true)
+
+        itMovesByWord('b', alt: true)
+
+      describe "with it configured to be camel-case sensitive", ->
+        beforeEach -> atom.config.set('vim-mode.defaultWordIsCamelCaseSensitive', false)
+
+        itMovesBySubword('b', alt: true)
+
   describe "the B keybinding", ->
     beforeEach -> editor.setText("cde1+- ab \n\t xyz-123\n\n zip")
 

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -144,15 +144,6 @@ describe "Motions", ->
         keydown('w')
         expect(editor.getCursorScreenPosition()).toEqual [2, 0]
 
-        # FIXME: The definition of Cursor#getEndOfCurrentWordBufferPosition,
-        # means that the end of the word can't be the current cursor
-        # position (even though it is when your cursor is on a new line).
-        #
-        # Therefore it picks the end of the next word here (which is [3,3])
-        # to start looking for the next word, which is also the end of the
-        # buffer so the cursor never advances.
-        #
-        # See atom/vim-mode#3
         keydown('w')
         expect(editor.getCursorScreenPosition()).toEqual [3, 0]
 

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -464,62 +464,73 @@ describe "Motions", ->
       it 'selects to the beginning of the current paragraph', ->
         expect(vimState.getRegister('"').text).toBe "\nzip\n"
 
-  describe "the b keybinding", ->
-    beforeEach -> editor.setText(" ab cde1+- \n xyz\n\nzip }\n last")
+  describe "the b and alt-b keybindings", ->
+    itMovesByWord = (key, options) ->
+      describe "moving by word", ->
+        beforeEach -> editor.setText(" ab = cDeFg1+- \n xyz\n\nzip }\n last")
 
-    describe "as a motion", ->
-      beforeEach -> editor.setCursorScreenPosition([4, 1])
+        describe "as a motion", ->
+          beforeEach -> editor.setCursorScreenPosition([4, 1])
 
-      it "moves the cursor to the beginning of the previous word", ->
-        keydown('b')
-        expect(editor.getCursorScreenPosition()).toEqual [3, 4]
+          it "moves the cursor to the beginning of the previous word", ->
+            keydown('b')
+            expect(editor.getCursorScreenPosition()).toEqual [3, 4]
 
-        keydown('b')
-        expect(editor.getCursorScreenPosition()).toEqual [3, 0]
+            keydown('b')
+            expect(editor.getCursorScreenPosition()).toEqual [3, 0]
 
-        keydown('b')
-        expect(editor.getCursorScreenPosition()).toEqual [2, 0]
+            keydown('b')
+            expect(editor.getCursorScreenPosition()).toEqual [2, 0]
 
-        keydown('b')
-        expect(editor.getCursorScreenPosition()).toEqual [1, 1]
+            keydown('b')
+            expect(editor.getCursorScreenPosition()).toEqual [1, 1]
 
-        keydown('b')
-        expect(editor.getCursorScreenPosition()).toEqual [0, 8]
+            keydown('b')
+            expect(editor.getCursorScreenPosition()).toEqual [0, 12]
 
-        keydown('b')
-        expect(editor.getCursorScreenPosition()).toEqual [0, 4]
+            keydown('b')
+            expect(editor.getCursorScreenPosition()).toEqual [0, 6]
 
-        keydown('b')
-        expect(editor.getCursorScreenPosition()).toEqual [0, 1]
+            keydown('b')
+            expect(editor.getCursorScreenPosition()).toEqual [0, 4]
 
-        # Go to start of the file, after moving past the first word
-        keydown('b')
-        expect(editor.getCursorScreenPosition()).toEqual [0, 0]
+            keydown('b')
+            expect(editor.getCursorScreenPosition()).toEqual [0, 1]
 
-        # Stay at the start of the file
-        keydown('b')
-        expect(editor.getCursorScreenPosition()).toEqual [0, 0]
+            # Go to start of the file, after moving past the first word
+            keydown('b')
+            expect(editor.getCursorScreenPosition()).toEqual [0, 0]
 
-    describe "as a selection", ->
-      describe "within a word", ->
-        beforeEach ->
-          editor.setCursorScreenPosition([0, 2])
-          keydown('y')
-          keydown('b')
+            # Stay at the start of the file
+            keydown('b')
+            expect(editor.getCursorScreenPosition()).toEqual [0, 0]
 
-        it "selects to the beginning of the current word", ->
-          expect(vimState.getRegister('"').text).toBe 'a'
-          expect(editor.getCursorScreenPosition()).toEqual [0, 1]
+        describe "as a selection", ->
+          describe "within a word", ->
+            beforeEach ->
+              editor.setCursorScreenPosition([0, 2])
+              keydown('y')
+              keydown('b')
 
-      describe "between words", ->
-        beforeEach ->
-          editor.setCursorScreenPosition([0, 4])
-          keydown('y')
-          keydown('b')
+            it "selects to the beginning of the current word", ->
+              expect(vimState.getRegister('"').text).toBe 'a'
+              expect(editor.getCursorScreenPosition()).toEqual [0, 1]
 
-        it "selects to the beginning of the last word", ->
-          expect(vimState.getRegister('"').text).toBe 'ab '
-          expect(editor.getCursorScreenPosition()).toEqual [0, 1]
+          describe "between words", ->
+            beforeEach ->
+              editor.setCursorScreenPosition([0, 4])
+              keydown('y')
+              keydown('b')
+
+            it "selects to the beginning of the last word", ->
+              expect(vimState.getRegister('"').text).toBe 'ab '
+              expect(editor.getCursorScreenPosition()).toEqual [0, 1]
+
+    describe "the b keybinding", ->
+      describe "with it configured to be camel-case insensitive", ->
+        beforeEach -> atom.config.set('vim-mode.defaultWordIsCamelCaseSensitive', false)
+
+        itMovesByWord('b')
 
   describe "the B keybinding", ->
     beforeEach -> editor.setText("cde1+- ab \n\t xyz-123\n\n zip")

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -473,54 +473,124 @@ describe "Motions", ->
           beforeEach -> editor.setCursorScreenPosition([4, 1])
 
           it "moves the cursor to the beginning of the previous word", ->
-            keydown('b')
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [3, 4]
 
-            keydown('b')
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [3, 0]
 
-            keydown('b')
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [2, 0]
 
-            keydown('b')
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [1, 1]
 
-            keydown('b')
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [0, 12]
 
-            keydown('b')
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [0, 6]
 
-            keydown('b')
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [0, 4]
 
-            keydown('b')
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [0, 1]
 
             # Go to start of the file, after moving past the first word
-            keydown('b')
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [0, 0]
 
             # Stay at the start of the file
-            keydown('b')
+            keydown(key, options)
             expect(editor.getCursorScreenPosition()).toEqual [0, 0]
 
         describe "as a selection", ->
           describe "within a word", ->
             beforeEach ->
-              editor.setCursorScreenPosition([0, 2])
+              editor.setCursorScreenPosition([0, 10])
               keydown('y')
-              keydown('b')
+              keydown(key, options)
 
             it "selects to the beginning of the current word", ->
-              expect(vimState.getRegister('"').text).toBe 'a'
-              expect(editor.getCursorScreenPosition()).toEqual [0, 1]
+              expect(vimState.getRegister('"').text).toBe "cDeF"
+              expect(editor.getCursorScreenPosition()).toEqual [0, 6]
 
           describe "between words", ->
             beforeEach ->
               editor.setCursorScreenPosition([0, 4])
               keydown('y')
-              keydown('b')
+              keydown(key, options)
+
+            it "selects to the beginning of the last word", ->
+              expect(vimState.getRegister('"').text).toBe 'ab '
+              expect(editor.getCursorScreenPosition()).toEqual [0, 1]
+
+    itMovesBySubword = (key, options) ->
+      describe "moving by subword", ->
+        beforeEach -> editor.setText(" ab = cDeFg1+- \n xyz\n\nzip }\n last")
+
+        describe "as a motion", ->
+          beforeEach -> editor.setCursorScreenPosition([4, 1])
+
+          it "moves the cursor to the beginning of the previous word", ->
+            keydown(key, options)
+            expect(editor.getCursorScreenPosition()).toEqual [3, 4]
+
+            keydown(key, options)
+            expect(editor.getCursorScreenPosition()).toEqual [3, 0]
+
+            keydown(key, options)
+            expect(editor.getCursorScreenPosition()).toEqual [2, 0]
+
+            keydown(key, options)
+            expect(editor.getCursorScreenPosition()).toEqual [1, 1]
+
+            keydown(key, options)
+            expect(editor.getCursorScreenPosition()).toEqual [0, 12]
+
+            keydown(key, options)
+            expect(editor.getCursorScreenPosition()).toEqual [0, 11]
+
+            keydown(key, options)
+            expect(editor.getCursorScreenPosition()).toEqual [0, 9]
+
+            keydown(key, options)
+            expect(editor.getCursorScreenPosition()).toEqual [0, 7]
+
+            keydown(key, options)
+            expect(editor.getCursorScreenPosition()).toEqual [0, 6]
+
+            keydown(key, options)
+            expect(editor.getCursorScreenPosition()).toEqual [0, 4]
+
+            keydown(key, options)
+            expect(editor.getCursorScreenPosition()).toEqual [0, 1]
+
+            # Go to start of the file, after moving past the first word
+            keydown(key, options)
+            expect(editor.getCursorScreenPosition()).toEqual [0, 0]
+
+            # Stay at the start of the file
+            keydown(key, options)
+            expect(editor.getCursorScreenPosition()).toEqual [0, 0]
+
+        describe "as a selection", ->
+          describe "within a word", ->
+            beforeEach ->
+              editor.setCursorScreenPosition([0, 10])
+              keydown('y')
+              keydown(key, options)
+
+            it "selects to the beginning of the current word", ->
+              expect(vimState.getRegister('"').text).toBe "F"
+              expect(editor.getCursorScreenPosition()).toEqual [0, 9]
+
+          describe "between words", ->
+            beforeEach ->
+              editor.setCursorScreenPosition([0, 4])
+              keydown('y')
+              keydown(key, options)
 
             it "selects to the beginning of the last word", ->
               expect(vimState.getRegister('"').text).toBe 'ab '
@@ -531,6 +601,11 @@ describe "Motions", ->
         beforeEach -> atom.config.set('vim-mode.defaultWordIsCamelCaseSensitive', false)
 
         itMovesByWord('b')
+
+      describe "with it configured to be camel-case sensitive", ->
+        beforeEach -> atom.config.set('vim-mode.defaultWordIsCamelCaseSensitive', true)
+
+        itMovesBySubword('b')
 
   describe "the B keybinding", ->
     beforeEach -> editor.setText("cde1+- ab \n\t xyz-123\n\n zip")


### PR DESCRIPTION
I will be fleshing out some ideas for #377 in this PR. Comments and feedback are welcome. When all of the main changes are made and you agree and are happy with them, I can clean up the commit history and add the necessary documentation etc.

The general idea is that there will be 3 different definitions of a word. The main one, an alternative one and the space delimited (*WORD*) one. The only difference between the main and the alt one would be that one of them would be sensitive to camel (and snake?) casing and the other would not.

TODO:
 - [x] add a configuration option that says whether a CamelCase sensitive or insensitive definition of a *word* is used by default
 - [ ] add an alternative version for the <kbd>w</kbd> movement
   - [ ] revert or re-fix https://github.com/atom/atom/commit/ba3ab41
   - [ ] fix the tests that fail when <kbd>Alt</kbd> is used as a modifier
   - [ ] wait until atom/atom#7658 has been fixed and see if it fixes the already added tests
 - [ ] add an alternative version for the <kbd>b</kbd> movement
 - [ ] add an alternative version for the <kbd>e</kbd> movement
 - [ ] add an alternative version for the <kbd>w</kbd> text object
 - [ ] **?** add an alternative version for the <kbd>Ctrl</kbd>-<kbd>w</kbd> binding in the insert mode
