### PR TITLE
clean up: remove unused selectOptions and allowEOL

### DIFF
--- a/lib/operators/general-operators.coffee
+++ b/lib/operators/general-operators.coffee
@@ -12,11 +12,8 @@ class Operator
   vimState: null
   motion: null
   complete: null
-  selectOptions: null
 
-  # selectOptions - The options object to pass through to the motion when
-  #                 selecting.
-  constructor: (@editor, @vimState, {@selectOptions}={}) ->
+  constructor: (@editor, @vimState) ->
     @complete = false
 
   # Public: Determines when the command can be executed.
@@ -80,10 +77,8 @@ class Delete extends Operator
 
   # allowEOL - Determines whether the cursor should be allowed to rest on the
   #            end of line character or not.
-  constructor: (@editor, @vimState, {@allowEOL, @selectOptions}={}) ->
+  constructor: (@editor, @vimState, {@allowEOL}={}) ->
     @complete = false
-    @selectOptions ?= {}
-    @selectOptions.requireEOL ?= true
     @register = settings.defaultRegister()
 
   # Public: Deletes the text selected by the given motion.
@@ -92,7 +87,7 @@ class Delete extends Operator
   #
   # Returns nothing.
   execute: (count) ->
-    if _.contains(@motion.select(count, @selectOptions), true)
+    if _.contains(@motion.select(count), true)
       @setTextRegister(@register, @editor.getSelectedText())
       @editor.transact =>
         for selection in @editor.getSelections()
@@ -109,11 +104,11 @@ class Delete extends Operator
 # It toggles the case of everything selected by the following motion
 #
 class ToggleCase extends Operator
-  constructor: (@editor, @vimState, {@complete, @selectOptions}={}) ->
+  constructor: (@editor, @vimState, {@complete}={}) ->
 
   execute: (count=1) ->
     if @motion?
-      if _.contains(@motion.select(count, @selectOptions), true)
+      if _.contains(@motion.select(count), true)
         @editor.replaceSelectedText {}, (text) ->
           text.split('').map((char) ->
             lower = char.toLowerCase()
@@ -147,11 +142,11 @@ class ToggleCase extends Operator
 # In visual mode or after `g` with a motion, it makes the selection uppercase
 #
 class UpperCase extends Operator
-  constructor: (@editor, @vimState, {@selectOptions}={}) ->
+  constructor: (@editor, @vimState) ->
     @complete = false
 
   execute: (count=1) ->
-    if _.contains(@motion.select(count, @selectOptions), true)
+    if _.contains(@motion.select(count), true)
       @editor.replaceSelectedText {}, (text) ->
         text.toUpperCase()
 
@@ -161,11 +156,11 @@ class UpperCase extends Operator
 # In visual mode or after `g` with a motion, it makes the selection lowercase
 #
 class LowerCase extends Operator
-  constructor: (@editor, @vimState, {@selectOptions}={}) ->
+  constructor: (@editor, @vimState) ->
     @complete = false
 
   execute: (count=1) ->
-    if _.contains(@motion.select(count, @selectOptions), true)
+    if _.contains(@motion.select(count), true)
       @editor.replaceSelectedText {}, (text) ->
         text.toLowerCase()
 
@@ -177,7 +172,7 @@ class LowerCase extends Operator
 class Yank extends Operator
   register: null
 
-  constructor: (@editor, @vimState, {@allowEOL, @selectOptions}={}) ->
+  constructor: (@editor, @vimState, {@allowEOL}={}) ->
     @register = settings.defaultRegister()
 
   # Public: Copies the text selected by the given motion.
@@ -208,7 +203,7 @@ class Yank extends Operator
 # It combines the current line with the following line.
 #
 class Join extends Operator
-  constructor: (@editor, @vimState, {@selectOptions}={}) -> @complete = true
+  constructor: (@editor, @vimState) -> @complete = true
 
   # Public: Combines the current with the following lines
   #
@@ -225,7 +220,7 @@ class Join extends Operator
 # Repeat the last operation
 #
 class Repeat extends Operator
-  constructor: (@editor, @vimState, {@selectOptions}={}) -> @complete = true
+  constructor: (@editor, @vimState) -> @complete = true
 
   isRecordable: -> false
 
@@ -238,7 +233,7 @@ class Repeat extends Operator
 # It creates a mark at the current cursor position
 #
 class Mark extends OperatorWithInput
-  constructor: (@editor, @vimState, {@selectOptions}={}) ->
+  constructor: (@editor, @vimState) ->
     super(@editor, @vimState)
     @viewModel = new ViewModel(this, class: 'mark', singleChar: true, hidden: true)
 

--- a/lib/operators/general-operators.coffee
+++ b/lib/operators/general-operators.coffee
@@ -73,11 +73,8 @@ class OperatorWithInput extends Operator
 #
 class Delete extends Operator
   register: null
-  allowEOL: null
 
-  # allowEOL - Determines whether the cursor should be allowed to rest on the
-  #            end of line character or not.
-  constructor: (@editor, @vimState, {@allowEOL}={}) ->
+  constructor: (@editor, @vimState) ->
     @complete = false
     @register = settings.defaultRegister()
 
@@ -172,7 +169,7 @@ class LowerCase extends Operator
 class Yank extends Operator
   register: null
 
-  constructor: (@editor, @vimState, {@allowEOL}={}) ->
+  constructor: (@editor, @vimState) ->
     @register = settings.defaultRegister()
 
   # Public: Copies the text selected by the given motion.

--- a/lib/operators/input.coffee
+++ b/lib/operators/input.coffee
@@ -81,7 +81,7 @@ class Change extends Insert
   standalone: false
   register: null
 
-  constructor: (@editor, @vimState, {@selectOptions}={}) ->
+  constructor: (@editor, @vimState) ->
     @register = settings.defaultRegister()
 
   # Public: Changes the text selected by the given motion.
@@ -111,7 +111,7 @@ class Change extends Insert
 class Substitute extends Insert
   register: null
 
-  constructor: (@editor, @vimState, {@selectOptions}={}) ->
+  constructor: (@editor, @vimState) ->
     @register = settings.defaultRegister()
 
   execute: (count=1) ->
@@ -131,7 +131,7 @@ class Substitute extends Insert
 class SubstituteLine extends Insert
   register: null
 
-  constructor: (@editor, @vimState, {@selectOptions}={}) ->
+  constructor: (@editor, @vimState) ->
     @register = settings.defaultRegister()
 
   execute: (count=1) ->

--- a/lib/operators/put-operator.coffee
+++ b/lib/operators/put-operator.coffee
@@ -9,7 +9,7 @@ module.exports =
 class Put extends Operator
   register: null
 
-  constructor: (@editor, @vimState, {@location, @selectOptions}={}) ->
+  constructor: (@editor, @vimState, {@location}={}) ->
     @location ?= 'after'
     @complete = true
     @register = settings.defaultRegister()

--- a/lib/operators/replace-operator.coffee
+++ b/lib/operators/replace-operator.coffee
@@ -5,7 +5,7 @@ _ = require 'underscore-plus'
 
 module.exports =
 class Replace extends OperatorWithInput
-  constructor: (@editor, @vimState, {@selectOptions}={}) ->
+  constructor: (@editor, @vimState) ->
     super(@editor, @vimState)
     @viewModel = new ViewModel(this, class: 'replace', hidden: true, singleChar: true, defaultText: '\n')
 


### PR DESCRIPTION
We never do use those parameters. Adapting #581 to not use selectOptions is quite simple.