### PR TITLE
Canceling c operator

### DIFF
--- a/lib/operators/input.coffee
+++ b/lib/operators/input.coffee
@@ -111,11 +111,11 @@ class Change extends Insert
   #
   # Returns nothing.
   execute: (count) ->
-    # If we've typed, we're being repeated. If we're being repeated,
-    # undo transactions are already handled.
-    @vimState.setInsertionCheckpoint() unless @typingCompleted
-
     if _.contains(@motion.select(count, excludeWhitespace: true), true)
+      # If we've typed, we're being repeated. If we're being repeated,
+      # undo transactions are already handled.
+      @vimState.setInsertionCheckpoint() unless @typingCompleted
+
       @setTextRegister(@register, @editor.getSelectedText())
       if @motion.isLinewise?() and not @typingCompleted
         for selection in @editor.getSelections()
@@ -125,10 +125,12 @@ class Change extends Insert
         for selection in @editor.getSelections()
           selection.deleteSelectedText()
 
-    return super if @typingCompleted
+      return super if @typingCompleted
 
-    @vimState.activateInsertMode()
-    @typingCompleted = true
+      @vimState.activateInsertMode()
+      @typingCompleted = true
+    else
+      @vimState.activateCommandMode()
 
 class SubstituteLine extends Change
   standalone: true

--- a/lib/operators/input.coffee
+++ b/lib/operators/input.coffee
@@ -130,7 +130,7 @@ class Change extends Insert
       @vimState.activateInsertMode()
       @typingCompleted = true
     else
-      @vimState.activateCommandMode()
+      @vimState.activateNormalMode()
 
 class SubstituteLine extends Change
   standalone: true

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -1524,10 +1524,10 @@ describe "Motions", ->
     it "cancels c when no match found", ->
       keydown('c')
       keydown('f')
-      commandModeInputKeydown('d')
+      normalModeInputKeydown('d')
       expect(editor.getText()).toBe("abcabcabcabc\n")
       expect(editor.getCursorScreenPosition()).toEqual [0, 0]
-      expect(vimState.mode).toBe "command"
+      expect(vimState.mode).toBe "normal"
 
   describe 'the t/T keybindings', ->
     beforeEach ->

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -1521,6 +1521,14 @@ describe "Motions", ->
       normalModeInputKeydown('a')
       expect(editor.getText()).toEqual 'abcbc\n'
 
+    it "cancels c when no match found", ->
+      keydown('c')
+      keydown('f')
+      commandModeInputKeydown('d')
+      expect(editor.getText()).toBe("abcabcabcabc\n")
+      expect(editor.getCursorScreenPosition()).toEqual [0, 0]
+      expect(vimState.mode).toBe "command"
+
   describe 'the t/T keybindings', ->
     beforeEach ->
       editor.setText("abcabcabcabc\n")

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -728,7 +728,7 @@ describe "Operators", ->
 
         it "undoes correctly with u", ->
           keydown('escape')
-          expect(vimState.mode).toBe "command"
+          expect(vimState.mode).toBe "normal"
           keydown 'u'
           expect(editor.getText()).toBe("12345(67)8\nabc(d)e\nA()BCDE")
 
@@ -752,7 +752,7 @@ describe "Operators", ->
           keydown('c')
           keydown('%')
           expect(editor.getText()).toBe("12345(67)8\nabc(d)e\nABCDE")
-          expect(vimState.mode).toBe "command"
+          expect(vimState.mode).toBe "normal"
 
       describe "repetition with .", ->
         beforeEach ->
@@ -766,33 +766,33 @@ describe "Operators", ->
           editor.setCursorScreenPosition([1, 0])
           keydown('.')
           expect(editor.getText()).toBe("1x8\nxe\nA()BCDE")
-          expect(vimState.mode).toBe "command"
+          expect(vimState.mode).toBe "normal"
 
         it "repeats correctly on the opening bracket", ->
           editor.setCursorScreenPosition([1, 3])
           keydown('.')
           expect(editor.getText()).toBe("1x8\nabcxe\nA()BCDE")
-          expect(vimState.mode).toBe "command"
+          expect(vimState.mode).toBe "normal"
 
         it "repeats correctly inside brackets", ->
           editor.setCursorScreenPosition([1, 4])
           keydown('.')
           # this differs from VIM, which deletes the character originally under cursor
           expect(editor.getText()).toBe("1x8\nabcxd)e\nA()BCDE")
-          expect(vimState.mode).toBe "command"
+          expect(vimState.mode).toBe "normal"
 
         it "repeats correctly on the closing bracket", ->
           editor.setCursorScreenPosition([1, 5])
           keydown('.')
           # this differs from VIM, which deletes the character originally under cursor
           expect(editor.getText()).toBe("1x8\nabcx)e\nA()BCDE")
-          expect(vimState.mode).toBe "command"
+          expect(vimState.mode).toBe "normal"
 
         it "does nothing when repeated after a bracket", ->
           editor.setCursorScreenPosition([2, 3])
           keydown('.')
           expect(editor.getText()).toBe("1x8\nabc(d)e\nA()BCDE")
-          expect(vimState.mode).toBe "command"
+          expect(vimState.mode).toBe "normal"
 
     describe "when followed by a goto line G", ->
       beforeEach ->

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -714,15 +714,23 @@ describe "Operators", ->
         editor.setText("12345(67)8\nabc(d)e\nA()BCDE")
 
       describe "before brackets or on the first one", ->
-        it "replaces inclusively until matching bracket", ->
+        beforeEach ->
           editor.setCursorScreenPosition([0, 1])
           editor.addCursorAtScreenPosition([1, 1])
           editor.addCursorAtScreenPosition([2, 1])
           keydown('c')
           keydown('%')
           editor.insertText('x')
+
+        it "replaces inclusively until matching bracket", ->
           expect(editor.getText()).toBe("1x8\naxe\nAxBCDE")
           expect(vimState.mode).toBe "insert"
+
+        it "undoes correctly with u", ->
+          keydown('escape')
+          expect(vimState.mode).toBe "command"
+          keydown 'u'
+          expect(editor.getText()).toBe("12345(67)8\nabc(d)e\nA()BCDE")
 
       describe "inside brackets or on the ending one", ->
         it "replaces inclusively backwards until matching bracket", ->
@@ -746,19 +754,13 @@ describe "Operators", ->
           expect(editor.getText()).toBe("12345(67)8\nabc(d)e\nABCDE")
           expect(vimState.mode).toBe "command"
 
-      describe "repeats correctly with .", ->
+      describe "repetition with .", ->
         beforeEach ->
           editor.setCursorScreenPosition([0, 1])
           keydown('c')
           keydown('%')
           editor.insertText('x')
           keydown('escape')
-
-        it "undoes correctly with u", ->
-          expect(editor.getText()).toBe("1x8\nabc(d)e\nA()BCDE")
-          expect(vimState.mode).toBe "command"
-          keydown 'u'
-          expect(editor.getText()).toBe("12345(67)8\nabc(d)e\nA()BCDE")
 
         it "repeats correctly before a bracket", ->
           editor.setCursorScreenPosition([1, 0])

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -709,6 +709,89 @@ describe "Operators", ->
           keydown('escape')
           expect(editor.getText()).toBe("12345\n\n")
 
+    describe "when followed by a %", ->
+      beforeEach ->
+        editor.setText("12345(67)8\nabc(d)e\nA()BCDE")
+
+      describe "before brackets or on the first one", ->
+        it "replaces inclusively until matching bracket", ->
+          editor.setCursorScreenPosition([0, 1])
+          editor.addCursorAtScreenPosition([1, 1])
+          editor.addCursorAtScreenPosition([2, 1])
+          keydown('c')
+          keydown('%')
+          editor.insertText('x')
+          expect(editor.getText()).toBe("1x8\naxe\nAxBCDE")
+          expect(vimState.mode).toBe "insert"
+
+      describe "inside brackets or on the ending one", ->
+        it "replaces inclusively backwards until matching bracket", ->
+          editor.setCursorScreenPosition([0, 6])
+          editor.addCursorAtScreenPosition([1, 5])
+          editor.addCursorAtScreenPosition([2, 2])
+          keydown('c')
+          keydown('%')
+          editor.insertText('x')
+          # this differs from VIM, which deletes the character originally under cursor
+          expect(editor.getText()).toBe("12345x67)8\nabcx)e\nAx)BCDE")
+          expect(vimState.mode).toBe "insert"
+
+      describe "after or without brackets", ->
+        it "deletes nothing", ->
+          editor.setText("12345(67)8\nabc(d)e\nABCDE")
+          editor.setCursorScreenPosition([0, 9])
+          editor.addCursorAtScreenPosition([2, 2])
+          keydown('c')
+          keydown('%')
+          expect(editor.getText()).toBe("12345(67)8\nabc(d)e\nABCDE")
+          expect(vimState.mode).toBe "command"
+
+      describe "repeats correctly with .", ->
+        beforeEach ->
+          editor.setCursorScreenPosition([0, 1])
+          keydown('c')
+          keydown('%')
+          editor.insertText('x')
+          keydown('escape')
+
+        it "undoes correctly with u", ->
+          expect(editor.getText()).toBe("1x8\nabc(d)e\nA()BCDE")
+          expect(vimState.mode).toBe "command"
+          keydown 'u'
+          expect(editor.getText()).toBe("12345(67)8\nabc(d)e\nA()BCDE")
+
+        it "repeats correctly before a bracket", ->
+          editor.setCursorScreenPosition([1, 0])
+          keydown('.')
+          expect(editor.getText()).toBe("1x8\nxe\nA()BCDE")
+          expect(vimState.mode).toBe "command"
+
+        it "repeats correctly on the opening bracket", ->
+          editor.setCursorScreenPosition([1, 3])
+          keydown('.')
+          expect(editor.getText()).toBe("1x8\nabcxe\nA()BCDE")
+          expect(vimState.mode).toBe "command"
+
+        it "repeats correctly inside brackets", ->
+          editor.setCursorScreenPosition([1, 4])
+          keydown('.')
+          # this differs from VIM, which deletes the character originally under cursor
+          expect(editor.getText()).toBe("1x8\nabcxd)e\nA()BCDE")
+          expect(vimState.mode).toBe "command"
+
+        it "repeats correctly on the closing bracket", ->
+          editor.setCursorScreenPosition([1, 5])
+          keydown('.')
+          # this differs from VIM, which deletes the character originally under cursor
+          expect(editor.getText()).toBe("1x8\nabcx)e\nA()BCDE")
+          expect(vimState.mode).toBe "command"
+
+        it "does nothing when repeated after a bracket", ->
+          editor.setCursorScreenPosition([2, 3])
+          keydown('.')
+          expect(editor.getText()).toBe("1x8\nabc(d)e\nA()BCDE")
+          expect(vimState.mode).toBe "command"
+
     describe "when followed by a goto line G", ->
       beforeEach ->
         editor.setText "12345\nabcde\nABCDE"


### PR DESCRIPTION
When a motion matches nothing, e.g. `%` on a line without brackets, or `fx` on a line without x, `c` should be cancelled and go into command mode; currently it simply behaves like `i`. 
This PR implements the desired behaviour.

Also, this PR adds a lot of tests for `c%`; I wrote those when I mistakenly thought there was some other problem there so I wanted to document the desired behaviour and fix it, and then I found it already worked as I'd described it. If the tests are undesirable, I can remove them.