### PR TITLE
hide input outline

### DIFF
--- a/styles/vim-mode.less
+++ b/styles/vim-mode.less
@@ -11,6 +11,9 @@
   cursor: default;
   white-space: nowrap;
   padding-left: 10px;
+  &.is-focused {
+    box-shadow: none;
+  }
 }
 
 .block-cursor(@visibility: visible) {


### PR DESCRIPTION
I use one-dark-ui or one-light-ui theme.
For  mini editor used in `f` command, outline is shown bottom of window.

This PR hide this outline.

![image](https://cloud.githubusercontent.com/assets/155205/8740294/f8493846-2c81-11e5-8d49-926e7fd959b2.png)
