### PR TITLE
Hide command input field better

### DIFF
--- a/lib/view-models/search-view-model.coffee
+++ b/lib/view-models/search-view-model.coffee
@@ -43,8 +43,8 @@ class SearchViewModel extends ViewModel
 
   update: (reverse) ->
     if reverse
-      @view.editorContainer.classList.add('reverse-search-input')
-      @view.editorContainer.classList.remove('search-input')
+      @view.classList.add('reverse-search-input')
+      @view.classList.remove('search-input')
     else
-      @view.editorContainer.classList.add('search-input')
-      @view.editorContainer.classList.remove('reverse-search-input')
+      @view.classList.add('search-input')
+      @view.classList.remove('reverse-search-input')

--- a/lib/view-models/view-model.coffee
+++ b/lib/view-models/view-model.coffee
@@ -3,7 +3,7 @@ VimNormalModeInputElement = require './vim-normal-mode-input-element'
 class ViewModel
   constructor: (@operation, opts={}) ->
     {@editor, @vimState} = @operation
-    @view = new VimNormalModeInputElement().initialize(this, opts)
+    @view = new VimNormalModeInputElement().initialize(this, atom.views.getView(@editor), opts)
     @editor.normalModeInputView = @view
     @vimState.onDidFailToCompose => @view.remove()
 
@@ -13,6 +13,7 @@ class ViewModel
   cancel: (view) ->
     if @vimState.isOperatorPending()
       @vimState.pushOperations(new Input(''))
+    delete @editor.normalModeInputView
 
 class Input
   constructor: (@characters) ->

--- a/lib/view-models/vim-normal-mode-input-element.coffee
+++ b/lib/view-models/vim-normal-mode-input-element.coffee
@@ -54,7 +54,7 @@ class VimNormalModeInputElement extends HTMLDivElement
     if @panel?
       @panel.destroy()
     else
-      this.parentNode.removeChild(this) if this.parentNode?
+      this.remove()
 
 module.exports =
 document.registerElement("vim-normal-mode-input"

--- a/lib/view-models/vim-normal-mode-input-element.coffee
+++ b/lib/view-models/vim-normal-mode-input-element.coffee
@@ -2,28 +2,24 @@ class VimNormalModeInputElement extends HTMLDivElement
   createdCallback: ->
     @className = "normal-mode-input"
 
-    @editorContainer = document.createElement("div")
-    @editorContainer.className = "editor-container"
-
-    @appendChild(@editorContainer)
-
-  initialize: (@viewModel, opts = {}) ->
+  initialize: (@viewModel, @mainEditorElement, opts = {}) ->
     if opts.class?
-      @editorContainer.classList.add(opts.class)
-
-    if opts.hidden
-      @editorContainer.style.height = "0px"
+      @classList.add(opts.class)
 
     @editorElement = document.createElement "atom-text-editor"
     @editorElement.classList.add('editor')
     @editorElement.getModel().setMini(true)
     @editorElement.setAttribute('mini', '')
-    @editorContainer.appendChild(@editorElement)
+    @appendChild(@editorElement)
 
     @singleChar = opts.singleChar
     @defaultText = opts.defaultText ? ''
 
-    @panel = atom.workspace.addBottomPanel(item: this, priority: 100)
+    if opts.hidden
+      @classList.add('vim-hidden-normal-mode-input')
+      @mainEditorElement.parentNode.appendChild(this)
+    else
+      @panel = atom.workspace.addBottomPanel(item: this, priority: 100)
 
     @focus()
     @handleEvents()
@@ -55,7 +51,10 @@ class VimNormalModeInputElement extends HTMLDivElement
 
   removePanel: ->
     atom.workspace.getActivePane().activate()
-    @panel.destroy()
+    if @panel?
+      @panel.destroy()
+    else
+      this.parentNode.removeChild(this) if this.parentNode?
 
 module.exports =
 document.registerElement("vim-normal-mode-input"

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -23,18 +23,19 @@ describe "Operators", ->
     editor.normalModeInputView.editorElement.getModel().setText(key)
 
   describe "cancelling operations", ->
-    it "does not throw an error even if no operation is pending", ->
+    it "would throw an error when no operation is pending", ->
       # cancel operation pushes an empty input operation
-      # doing this without a pending operation throws an exception
+      # doing this without a pending operation would throw an exception
       expect(-> vimState.pushOperations(new Input(''))).toThrow()
 
+    it "cancels and cleans up properly", ->
       # make sure normalModeInputView is created
       keydown('/')
       expect(vimState.isOperatorPending()).toBe true
       editor.normalModeInputView.viewModel.cancel()
 
       expect(vimState.isOperatorPending()).toBe false
-      expect(-> editor.normalModeInputView.viewModel.cancel()).not.toThrow()
+      expect(editor.normalModeInputView).toBe undefined
 
   describe "the x keybinding", ->
     describe "on a line with content", ->

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -23,7 +23,7 @@ describe "Operators", ->
     editor.normalModeInputView.editorElement.getModel().setText(key)
 
   describe "cancelling operations", ->
-    it "would throw an error when no operation is pending", ->
+    it "throws an error when no operation is pending", ->
       # cancel operation pushes an empty input operation
       # doing this without a pending operation would throw an exception
       expect(-> vimState.pushOperations(new Input(''))).toThrow()

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -28,6 +28,9 @@ getEditorElement = (callback) ->
     element.addEventListener "keydown", (e) ->
       atom.keymaps.handleKeyboardEvent(e)
 
+    # mock parent element for the text editor
+    document.createElement('html').appendChild(atom.views.getView(textEditor))
+
     callback(element)
 
 mockPlatform = (editorElement, platform) ->

--- a/spec/text-objects-spec.coffee
+++ b/spec/text-objects-spec.coffee
@@ -18,9 +18,6 @@ describe "TextObjects", ->
     options.element ?= editorElement
     helpers.keydown(key, options)
 
-  normalModeInputKeydown = (key, opts = {}) ->
-    editor.normalModeInputView.editorElement.getModel().setText(key)
-
   describe "Text Object commands in normal mode not preceded by an operator", ->
     beforeEach ->
       vimState.activateNormalMode()

--- a/styles/vim-mode.less
+++ b/styles/vim-mode.less
@@ -13,6 +13,17 @@
   padding-left: 10px;
 }
 
+atom-panel.bottom.vim-hidden-normal-mode-input {
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  border: none;
+  display: block;
+  position: fixed;
+  top: -1px;
+  left: -1px;
+}
+
 .block-cursor(@visibility: visible) {
   border: 0;
   background-color: @syntax-cursor-color;


### PR DESCRIPTION
Also removed the seemingly unnecessary editorContainer; this may
affect people’s personal styles if anybody has applied styles to that
container element.

The change in spec-helper makes sure that the new code’s expectations
are met when testing.

This is an alternative solution to PR #776.