### PR TITLE
beep on unrecognized commands to warn the user

### DIFF
--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -1,5 +1,8 @@
 {Range} = require 'atom'
 
+# copied from atom/atom-keymap src/helpers.coffee
+AtomModifierRegex = /(ctrl|alt|shift|cmd)$/
+
 module.exports =
   # Public: Determines if a string should be considered linewise or character
   #
@@ -25,3 +28,8 @@ module.exports =
       newRange
     else
       oldRange.union(newRange)
+
+  # copied and simplified from atom/atom-keymap src/helpers.coffee
+  # see atom/atom-keymap#97
+  isAtomModifier: (keystroke) ->
+    AtomModifierRegex.test(keystroke)

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -44,6 +44,12 @@ class VimState
     else
       @activateNormalMode()
 
+    @subscriptions.add atom.keymaps.onDidFailToMatchBinding (e) =>
+      return unless e.keyboardEventTarget is @editorElement
+      return if Utils.isAtomModifier(e.keystrokes)
+      if e.keystrokes.indexOf(' ') < 0 and @mode isnt "insert"
+        atom.beep()
+
   destroy: ->
     unless @destroyed
       @destroyed = true


### PR DESCRIPTION
Alternative to #764. Instead of trying to cancel an operation, possibly running into conflict with other packages' key bindings (as discussed in #764), this PR just beeps on unrecognised key bindings. 

Together with some form of showing the current pending key strokes (thought in progress), this could be a way of handling unrecognised commands that's more appropriate for Atom, even though it doesn't behave exactly like VIM.

Discussion welcome.
