### PR TITLE
fix cursor movement across beginning of selection

### DIFF
--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -85,6 +85,12 @@ class Motion
       if wasReversed and not wasEmpty and not isReversed
         selection.setBufferRange([[newStart.row, oldEnd.column - 1], newEnd])
 
+      # keep a single-character selection non-reversed
+      range = selection.getBufferRange()
+      [newStart, newEnd] = [range.start, range.end]
+      if selection.isReversed() and newStart.row is newEnd.row and newStart.column + 1 is newEnd.column
+        selection.setBufferRange(range, reversed: false)
+
   moveSelection: (selection, count, options) ->
     selection.modifySelection => @moveCursor(selection.cursor, count, options)
 

--- a/spec/vim-state-spec.coffee
+++ b/spec/vim-state-spec.coffee
@@ -254,7 +254,6 @@ describe "VimState", ->
         expect(editor.getSelectedText()).toBe("t")
 
         keydown("l")
-        keydown("l")
         expect(editor.getSelectedText()).toBe("tw")
 
     describe "operators", ->


### PR DESCRIPTION
Left and right motion across the beginning of a selection behaves inconsistently.
On a line with the text `abcde` and cursor on the `c`:
 1. press `v` to enter visual mode, `c` is selected;
 2. press `l`, `cd` is selected;
 3. press `h`, `c` is selected;
 4. press `h`, `bc` is selected;
 5. press `l`, `c` is selected;
 6. press `l`, `c` is *still* selected but it should be `cd` now.
 7. press `l` and now you'll have the desired `cd` selected.
This PR fixes that.