### PR TITLE
Protect against edge cases with pane splits

### DIFF
--- a/lib/vim-mode.coffee
+++ b/lib/vim-mode.coffee
@@ -31,6 +31,19 @@ module.exports =
     @disposables.add new Disposable =>
       @vimStates.forEach (vimState) -> vimState.destroy()
 
+    # Protect against edge cases where after splitting a pane, input would be
+    #  enabled in the original pane in command mode
+    @disposables.add atom.workspace.onDidAddPane =>
+      for paneItem in atom.workspace.getPaneItems()
+        vimState = @vimStatesByEditor.get(paneItem)
+        if vimState? and vimState.mode isnt 'insert'
+          vimState.editorElement.component.setInputEnabled(false)
+    @disposables.add atom.workspace.onDidDestroyPane =>
+      for paneItem in atom.workspace.getPaneItems()
+        vimState = @vimStatesByEditor.get(paneItem)
+        if vimState? and vimState.mode isnt 'insert'
+          vimState.editorElement.component.setInputEnabled(false)
+
   deactivate: ->
     @disposables.dispose()
 

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -352,6 +352,22 @@ describe "Operators", ->
         expect(editor.getText()).toBe "  abcde\n"
         expect(editor.getCursorScreenPosition()).toEqual [0, 2]
 
+      it "doesn't insert a d when used with pane splits", ->
+        editor.setText("12345\nabcde\n\nABCDE")
+        editor.setCursorScreenPosition([1, 1])
+        atom.workspace.getActivePane().splitDown()
+
+        keydown('d')
+        keydown('d')
+        expect(editor.getText()).toBe "12345\n\nABCDE"
+
+        editor.setText("12345\nabcde\n\nABCDE")
+        editor.setCursorScreenPosition([1, 1])
+        atom.workspace.activatePreviousPane()
+        keydown('d')
+        keydown('d')
+        expect(editor.getText()).toBe "12345\n\nABCDE"
+
     describe "undo behavior", ->
       beforeEach ->
         editor.setText("12345\nabcde\nABCDE\nQWERT")


### PR DESCRIPTION
When splitting a pane, input would be enabled in the original pane in command
mode (Fixes #657)

Not really sure if the spec is in the right place :confused: 
