### PR TITLE
Text Objects in normal mode without a preceding operator should select text.

### DIFF
--- a/lib/text-objects.coffee
+++ b/lib/text-objects.coffee
@@ -8,6 +8,8 @@ class TextObject
   isComplete: -> true
   isRecordable: -> false
 
+  execute: -> @select.apply(this, arguments)
+
 class SelectInsideWord extends TextObject
   select: ->
     @editor.selectWordsContainingCursors()

--- a/spec/text-objects-spec.coffee
+++ b/spec/text-objects-spec.coffee
@@ -21,6 +21,17 @@ describe "TextObjects", ->
   normalModeInputKeydown = (key, opts = {}) ->
     editor.normalModeInputView.editorElement.getModel().setText(key)
 
+  describe "Text Object commands in normal mode not preceded by an operator", ->
+    beforeEach ->
+      vimState.activateNormalMode()
+
+    it "selects the appropriate text", ->
+      editor.setText("<html> text </html>")
+      editor.setCursorScreenPosition([0, 7])
+      # Users could dispatch it via the command palette
+      atom.commands.dispatch(editorElement, "vim-mode:select-inside-tags")
+      expect(editor.getSelectedScreenRange()).toEqual [[0, 6], [0, 12]]
+
   describe "the 'iw' text object", ->
     beforeEach ->
       editor.setText("12345 abcde ABCDE")


### PR DESCRIPTION
This should close issue #759. But I'm not entirely sure this code is the best way to deal with it so feedback is welcome!