### PR TITLE
fix replace-mode backspace behavior to something acceptable

### DIFF
--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -656,7 +656,7 @@ class VimState
   # Returns nothing.
   insertRegister: (name) ->
     text = @getRegister(name)?.text
-    @editor.insertText(text) if text?
+    @editor.insertText(text, groupUndo: true) if text?
 
   ensureCursorIsWithinLine: (cursor) =>
     return if @processing or @mode isnt 'normal'

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -1845,24 +1845,38 @@ describe "Operators", ->
       editor.insertText "foo"
       keydown "R", shift: true
 
-      editor.insertText "a"
-      editor.insertText "b"
+      # simulate every key press comes after a second
+      now = Date.now()
+      spyOn(Date, 'now').andCallFake -> now
+
+      # groupUndo is necessary to enable the normal grouping of undo changes
+      editor.insertText "a", groupUndo: true
+
+      now += 1000
+      editor.insertText "b", groupUndo: true
       expect(editor.getText()).toBe "12fooab5\n67890"
 
+      now += 1000
       keydown 'backspace', raw: true
       expect(editor.getText()).toBe "12fooa45\n67890"
 
-      editor.insertText "c"
+      now += 1000
+      editor.insertText "c", groupUndo: true
 
       expect(editor.getText()).toBe "12fooac5\n67890"
 
+      now += 1000
       keydown 'backspace', raw: true
+
+      now += 1000
       keydown 'backspace', raw: true
 
       expect(editor.getText()).toBe "12foo345\n67890"
       expect(editor.getSelectedText()).toBe ""
 
+      now += 1000
       keydown 'backspace', raw: true
+
       expect(editor.getText()).toBe "12foo345\n67890"
       expect(editor.getSelectedText()).toBe ""
 
@@ -1885,9 +1899,9 @@ describe "Operators", ->
 
     it "repeats correctly when backspace was used in the text", ->
       keydown "R", shift: true
-      editor.insertText "a"
+      editor.insertText "a", groupUndo: true
       keydown 'backspace', raw: true
-      editor.insertText "b"
+      editor.insertText "b", groupUndo: true
       keydown 'escape'
       editor.setCursorBufferPosition([1, 2])
       keydown '.'


### PR DESCRIPTION
Due to atom/text-buffer#81 and 30e4073c52f68221dccd3599dd60728f300b3534, backspace in replace mode hasn't been working well. 

For example, `ctrl-r x` to paste the `x` register would have backspace first undo the insert, then the delete, which looks wrong. Another example: when replacing after the end of the line, the grouping of multiple typed characters for undo confused our replace-mode backspace to no end.
