### PR TITLE
use arrow mouse cursor when in normal mode

### DIFF
--- a/styles/vim-mode.less
+++ b/styles/vim-mode.less
@@ -124,3 +124,14 @@ atom-text-editor.vim-mode.operator-pending-mode.is-focused
     }
   }
 }
+
+atom-text-editor.vim-mode.normal-mode
+{
+  &::shadow,
+  &
+  {
+    .editor-contents--private {
+      cursor: default;
+    }
+  }
+}


### PR DESCRIPTION
Seems nice.  Comes from https://github.com/atom/vim-mode/issues/750