### PR TITLE
Add visual feedback for search command ('/','?')

### DIFF
--- a/lib/motions/search-motion.coffee
+++ b/lib/motions/search-motion.coffee
@@ -77,6 +77,16 @@ class Search extends SearchBase
   constructor: (@editor, @vimState) ->
     super(@editor, @vimState)
     @viewModel = new SearchViewModel(this)
+    @updateViewModel()
+
+  reversed: =>
+    @initiallyReversed = @reverse = true
+    @updateCurrentSearch()
+    @updateViewModel()
+    this
+
+  updateViewModel: ->
+    @viewModel.update(@initiallyReversed)
 
 class SearchCurrentWord extends SearchBase
   @keywordRegex: null

--- a/lib/view-models/search-view-model.coffee
+++ b/lib/view-models/search-view-model.coffee
@@ -40,3 +40,11 @@ class SearchViewModel extends ViewModel
         atom.beep()
     super(view)
     @vimState.pushSearchHistory(@view.value)
+
+  update: (reverse) ->
+    if reverse
+      @view.editorContainer.classList.add('reverse-search-input')
+      @view.editorContainer.classList.remove('search-input')
+    else
+      @view.editorContainer.classList.add('search-input')
+      @view.editorContainer.classList.remove('reverse-search-input')

--- a/styles/vim-mode.less
+++ b/styles/vim-mode.less
@@ -124,3 +124,11 @@ atom-text-editor.vim-mode.operator-pending-mode.is-focused
     }
   }
 }
+
+.search-input atom-text-editor[mini]::before {
+  content: '/';
+}
+
+.reverse-search-input atom-text-editor[mini]::before {
+  content: '?';
+}


### PR DESCRIPTION
When doing a search, display the command '/' or '?' instead of
nothing. This gives the user a visual feedback about what he is
doing.
This is achieved by adding dynamically some classes to the
element container. The CSS class selectors associated display
a content ('/' or '?') before the container.