### PR TITLE
Fix #744

### DIFF
--- a/lib/operators/general-operators.coffee
+++ b/lib/operators/general-operators.coffee
@@ -194,7 +194,7 @@ class Yank extends Operator
     @setTextRegister(@register, text)
 
     @editor.setSelectedBufferRanges(newPositions.map (p) -> new Range(p, p))
-    @vimState.activateNormalMode()
+    @vimState.activateNormalMode(restoreColumn: false)
 
 #
 # It combines the current line with the following line.

--- a/lib/operators/indent-operators.coffee
+++ b/lib/operators/indent-operators.coffee
@@ -10,7 +10,7 @@ class AdjustIndentation extends Operator
 
     @editor.setCursorBufferPosition([start.row, 0])
     @editor.moveToFirstCharacterOfLine()
-    @vimState.activateNormalMode()
+    @vimState.activateNormalMode(restoreColumn: false)
 
 class Indent extends AdjustIndentation
   indent: ->

--- a/spec/vim-state-spec.coffee
+++ b/spec/vim-state-spec.coffee
@@ -389,10 +389,14 @@ describe "VimState", ->
     describe "activate visualmode witin visualmode", ->
       beforeEach ->
         keydown('escape')
+        editor.setText("line one\nline two\nline three\n")
+        editor.setCursorBufferPosition([0, 4])
         expect(vimState.mode).toEqual 'normal'
         expect(editorElement.classList.contains('normal-mode')).toBe(true)
 
-      it "activateVisualMode with same type puts the editor into normal mode", ->
+      it "activateVisualMode with same submode puts the editor into normal mode", ->
+        point = [0, 4]
+
         keydown('v')
         expect(editorElement.classList.contains('visual-mode')).toBe(true)
         expect(vimState.submode).toEqual 'characterwise'
@@ -401,6 +405,7 @@ describe "VimState", ->
         keydown('v')
         expect(vimState.mode).toEqual 'normal'
         expect(editorElement.classList.contains('normal-mode')).toBe(true)
+        expect(editor.getCursorBufferPosition()).toEqual(point)
 
         keydown('V', shift: true)
         expect(editorElement.classList.contains('visual-mode')).toBe(true)
@@ -410,6 +415,7 @@ describe "VimState", ->
         keydown('V', shift: true)
         expect(vimState.mode).toEqual 'normal'
         expect(editorElement.classList.contains('normal-mode')).toBe(true)
+        expect(editor.getCursorBufferPosition()).toEqual(point)
 
         keydown('v', ctrl: true)
         expect(editorElement.classList.contains('visual-mode')).toBe(true)
@@ -419,6 +425,7 @@ describe "VimState", ->
         keydown('v', ctrl: true)
         expect(vimState.mode).toEqual 'normal'
         expect(editorElement.classList.contains('normal-mode')).toBe(true)
+        expect(editor.getCursorBufferPosition()).toEqual(point)
 
       describe "change submode within visualmode", ->
         beforeEach ->


### PR DESCRIPTION
Its me originally add submode shift within visual mode, at that time, I skipped to cover following case.
So original cursor position wasn't preserved.
- Entering linewise visual-mode (from normal mode) by 'V'
- Exiting linewise visual-mode.

This PR save/restore original cursor position in above entering/exiting scenario.
