### PR TITLE
Fix cc on only line

### DIFF
--- a/lib/operators/input.coffee
+++ b/lib/operators/input.coffee
@@ -130,14 +130,6 @@ class Change extends Insert
     @vimState.activateInsertMode()
     @typingCompleted = true
 
-class SubstituteLine extends Change
-  standalone: true
-  register: null
-
-  constructor: (@editor, @vimState) ->
-    @register = settings.defaultRegister()
-    @motion = new Motions.MoveToRelativeLine(@editor, @vimState)
-
 # Takes a transaction and turns it into a string of what was typed.
 # This class is an implementation detail of Insert
 class TransactionBundler
@@ -212,6 +204,5 @@ module.exports = {
   InsertAboveWithNewline,
   InsertBelowWithNewline,
   ReplaceMode,
-  Change,
-  SubstituteLine
+  Change
 }

--- a/lib/operators/input.coffee
+++ b/lib/operators/input.coffee
@@ -119,7 +119,10 @@ class Change extends Insert
       @setTextRegister(@register, @editor.getSelectedText())
       if @motion.isLinewise?() and not @typingCompleted
         for selection in @editor.getSelections()
-          selection.insertText("\n", autoIndent: true)
+          if selection.getBufferRange().end.row is 0
+            selection.deleteSelectedText()
+          else
+            selection.insertText("\n", autoIndent: true)
           selection.cursor.moveLeft()
       else
         for selection in @editor.getSelections()

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -84,7 +84,7 @@ class VimState
       'activate-insert-mode': => new Operators.Insert(@editor, this)
       'activate-replace-mode': => new Operators.ReplaceMode(@editor, this)
       'substitute': => [new Operators.Change(@editor, this), new Motions.MoveRight(@editor, this)]
-      'substitute-line': => new Operators.SubstituteLine(@editor, this)
+      'substitute-line': => [new Operators.Change(@editor, this), new Motions.MoveToRelativeLine(@editor, this)]
       'insert-after': => new Operators.InsertAfter(@editor, this)
       'insert-after-end-of-line': => new Operators.InsertAfterEndOfLine(@editor, this)
       'insert-at-beginning-of-line': => new Operators.InsertAtBeginningOfLine(@editor, this)

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -650,7 +650,7 @@ describe "Operators", ->
           keydown('c')
           keydown('c')
 
-          expect(editor.getText()).toBe "\n"
+          expect(editor.getText()).toBe ""
           expect(editor.getCursorScreenPosition()).toEqual [0, 0]
           expect(editorElement.classList.contains('normal-mode')).toBe(false)
           expect(editorElement.classList.contains('insert-mode')).toBe(true)


### PR DESCRIPTION
On the only line in a file, `cc` should not add a `\n`.
Also, finished the implementation of SubstituteLine with Change (alias `S` to `cc` as it should be).