### PR TITLE
Add last insert/yank marks

### DIFF
--- a/lib/operators/input.coffee
+++ b/lib/operators/input.coffee
@@ -12,13 +12,15 @@ class Insert extends Operator
   isComplete: -> @standalone or super
 
   confirmChanges: (changes) ->
-    bundler = new TransactionBundler(changes, @editor)
+    @bundler = new TransactionBundler(changes, @editor)
     @typedText = bundler.buildInsertText()
 
   execute: ->
     if @typingCompleted
       return unless @typedText? and @typedText.length > 0
       @editor.insertText(@typedText, normalizeLineEndings: true)
+      @vimState.setMark '[', @bundler.start
+      @vimState.setMark ']', @bundler.end
       for cursor in @editor.getCursors()
         cursor.moveLeft() unless cursor.isAtBeginningOfLine()
     else

--- a/lib/operators/input.coffee
+++ b/lib/operators/input.coffee
@@ -14,13 +14,13 @@ class Insert extends Operator
   confirmChanges: (changes) ->
     bundler = new TransactionBundler(changes, @editor)
     @typedText = bundler.buildInsertText()
+    if @typedText? and @typedText.length > 0
+      @vimState.setLastInsertMarks bundler
 
   execute: ->
     if @typingCompleted
       return unless @typedText? and @typedText.length > 0
-      range = @editor.insertText(@typedText, normalizeLineEndings: true)
-      @vimState.setMark '[', range.start
-      @vimState.setMark ']', range.end
+      @editor.insertText(@typedText, normalizeLineEndings: true)
       for cursor in @editor.getCursors()
         cursor.moveLeft() unless cursor.isAtBeginningOfLine()
     else

--- a/lib/operators/input.coffee
+++ b/lib/operators/input.coffee
@@ -12,15 +12,15 @@ class Insert extends Operator
   isComplete: -> @standalone or super
 
   confirmChanges: (changes) ->
-    @bundler = new TransactionBundler(changes, @editor)
+    bundler = new TransactionBundler(changes, @editor)
     @typedText = bundler.buildInsertText()
 
   execute: ->
     if @typingCompleted
       return unless @typedText? and @typedText.length > 0
-      @editor.insertText(@typedText, normalizeLineEndings: true)
-      @vimState.setMark '[', @bundler.start
-      @vimState.setMark ']', @bundler.end
+      range = @editor.insertText(@typedText, normalizeLineEndings: true)
+      @vimState.setMark '[', range.start
+      @vimState.setMark ']', range.end
       for cursor in @editor.getCursors()
         cursor.moveLeft() unless cursor.isAtBeginningOfLine()
     else

--- a/lib/operators/put-operator.coffee
+++ b/lib/operators/put-operator.coffee
@@ -52,9 +52,8 @@ class Put extends Operator
         @editor.moveToBeginningOfLine()
         originalPosition = @editor.getCursorScreenPosition()
 
-    range = @editor.insertText(textToInsert)
-    @vimState.setMark '[', range.start
-    @vimState.setMark ']', range.end
+    [range] = @editor.insertText(textToInsert)
+    @vimState.setLastInsertMarks range
 
     if originalPosition?
       @editor.setCursorScreenPosition(originalPosition)

--- a/lib/operators/put-operator.coffee
+++ b/lib/operators/put-operator.coffee
@@ -52,7 +52,9 @@ class Put extends Operator
         @editor.moveToBeginningOfLine()
         originalPosition = @editor.getCursorScreenPosition()
 
-    @editor.insertText(textToInsert)
+    range = @editor.insertText(textToInsert)
+    @vimState.setMark '[', range.start
+    @vimState.setMark ']', range.end
 
     if originalPosition?
       @editor.setCursorScreenPosition(originalPosition)

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -679,6 +679,7 @@ class VimState
   # Returns nothing.
   setLastInsertMarks: (range) ->
     {start, end} = range
+    return if start.isEqual end
     @setMark '[', start
     @setMark ']', @getPreviousCharPosition(end)
 

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -367,8 +367,9 @@ class VimState
   #
   # Returns nothing.
   setMark: (name, pos) ->
-    # check to make sure name is in [a-z] or is `
-    if (charCode = name.charCodeAt(0)) >= 96 and charCode <= 122
+    # check to make sure name is in [a-z] OR is `, <, >, [ or ]
+    charCode = name.charCodeAt(0)
+    if (charCode >= 96 and charCode <= 122) or (charCode in [60, 62, 91, 93])
       marker = @editor.markBufferRange(new Range(pos, pos), {invalidate: 'never', persistent: false})
       @marks[name] = marker
 

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -672,6 +672,31 @@ class VimState
       @processing = false
     cursor.goalColumn = goalColumn
 
+  # Private: set marks [ and ] to first and last inserted characters
+  #
+  # range - the range of inserted characters
+  #
+  # Returns nothing.
+  setLastInsertMarks: (range) ->
+    {start, end} = range
+    @setMark '[', start
+    @setMark ']', @getPreviousCharPosition(end)
+
+  # Private: get the buffer position of the previous char
+  #
+  # position - the initial position:{Point}
+  #
+  # Returns the position of the previous char, or Point(0, 0) if point is at
+  # the begining of the file.
+  getPreviousCharPosition: (position) ->
+    {row, column} = position
+    unless column is 0
+      column -= 1
+    else unless row is 0
+      row   -= 1
+      column = @editor.lineTextForBufferRow(row).length - 1
+    return new Point(row, column)
+
 # This uses private APIs and may break if TextBuffer is refactored.
 # Package authors - copy and paste this code at your own risk.
 getChangesSinceCheckpoint = (buffer, checkpoint) ->

--- a/spec/vim-state-spec.coffee
+++ b/spec/vim-state-spec.coffee
@@ -475,3 +475,17 @@ describe "VimState", ->
       keydown('`')
       normalModeInputKeydown('q')
       expect(editor.getCursorScreenPosition()).toEqual [1, 2]
+
+    it "last-insert marks: '[' and ']'", ->
+      editor.setCursorBufferPosition([1, 0])
+      keydown('y')
+      keydown('y')
+      keydown('p')
+      editor.setCursorBufferPosition([0, 0])
+      keydown('`')
+      normalModeInputKeydown('[')
+      expect(editor.getCursorBufferPosition()).toEqual [2, 0]
+      keydown('escape')
+      keydown('`')
+      normalModeInputKeydown(']')
+      expect(editor.getCursorBufferPosition()).toEqual [2, 13]


### PR DESCRIPTION
Hello,

This PR implements the `[` and `]` marks. 
Do not hesitate to propose changes in implementation; I wrote it as I felt was better, but it's my first PR on this package, I'll be happy to have your feedback.

Basically, it adds `VimState::setLastInsertMarks`, and calls it when `Put` and `Insert` operators are done.

Adds `::getPreviousCharPosition` -> get the Point position of the char preceding the passed position.
The reason why is because vim's `(backtick)]` leaves the cursor on the last inserted character, not after.

Documentation: http://vimhelp.appspot.com/motion.txt.html#%27%5B
