### PR TITLE
Suppress beeps in specs

### DIFF
--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -994,6 +994,12 @@ describe "Motions", ->
       vimState.globalVimState.currentSearch = {}
 
     describe "as a motion", ->
+      it "beeps when repeating nonexistent last search", ->
+        keydown '/'
+        submitNormalModeInputText ''
+        expect(editor.getCursorBufferPosition()).toEqual [0, 0]
+        expect(atom.beep).toHaveBeenCalled()
+
       it "moves the cursor to the specified search pattern", ->
         keydown('/')
 
@@ -1001,6 +1007,7 @@ describe "Motions", ->
 
         expect(editor.getCursorBufferPosition()).toEqual [1, 0]
         expect(pane.activate).toHaveBeenCalled()
+        expect(atom.beep).not.toHaveBeenCalled()
 
       it "loops back around", ->
         editor.setCursorBufferPosition([3, 0])
@@ -1008,6 +1015,7 @@ describe "Motions", ->
         submitNormalModeInputText 'def'
 
         expect(editor.getCursorBufferPosition()).toEqual [1, 0]
+        expect(atom.beep).not.toHaveBeenCalled()
 
       it "uses a valid regex as a regex", ->
         keydown('/')
@@ -1016,6 +1024,7 @@ describe "Motions", ->
         expect(editor.getCursorBufferPosition()).toEqual [0, 1]
         keydown('n')
         expect(editor.getCursorBufferPosition()).toEqual [0, 2]
+        expect(atom.beep).not.toHaveBeenCalled()
 
       it "uses an invalid regex as a literal string", ->
         # Go straight to the literal [abc
@@ -1025,6 +1034,7 @@ describe "Motions", ->
         expect(editor.getCursorBufferPosition()).toEqual [1, 0]
         keydown('n')
         expect(editor.getCursorBufferPosition()).toEqual [1, 0]
+        expect(atom.beep).not.toHaveBeenCalled()
 
       it "uses ? as a literal string", ->
         editor.setText("abc\n[a?c?\n")
@@ -1033,6 +1043,7 @@ describe "Motions", ->
         expect(editor.getCursorBufferPosition()).toEqual [1, 2]
         keydown('n')
         expect(editor.getCursorBufferPosition()).toEqual [1, 4]
+        expect(atom.beep).not.toHaveBeenCalled()
 
       it 'works with selection in visual mode', ->
         editor.setText('one two three')
@@ -1042,6 +1053,7 @@ describe "Motions", ->
         expect(editor.getCursorBufferPosition()).toEqual [0, 9]
         keydown('d')
         expect(editor.getText()).toBe 'hree'
+        expect(atom.beep).not.toHaveBeenCalled()
 
       it 'extends selection when repeating search in visual mode', ->
         editor.setText('line1\nline2\nline3')
@@ -1055,6 +1067,7 @@ describe "Motions", ->
         {start, end} = editor.getSelectedBufferRange()
         expect(start.row).toEqual 0
         expect(end.row).toEqual 2
+        expect(atom.beep).not.toHaveBeenCalled()
 
       describe "case sensitivity", ->
         beforeEach ->
@@ -1067,18 +1080,21 @@ describe "Motions", ->
           expect(editor.getCursorBufferPosition()).toEqual [2, 0]
           keydown('n')
           expect(editor.getCursorBufferPosition()).toEqual [2, 0]
+          expect(atom.beep).not.toHaveBeenCalled()
 
         it "works in case insensitive mode", ->
           submitNormalModeInputText '\\cAbC'
           expect(editor.getCursorBufferPosition()).toEqual [1, 0]
           keydown('n')
           expect(editor.getCursorBufferPosition()).toEqual [2, 0]
+          expect(atom.beep).not.toHaveBeenCalled()
 
         it "works in case insensitive mode wherever \\c is", ->
           submitNormalModeInputText 'AbC\\c'
           expect(editor.getCursorBufferPosition()).toEqual [1, 0]
           keydown('n')
           expect(editor.getCursorBufferPosition()).toEqual [2, 0]
+          expect(atom.beep).not.toHaveBeenCalled()
 
         it "uses case insensitive search if useSmartcaseForSearch is true and searching lowercase", ->
           atom.config.set 'vim-mode.useSmartcaseForSearch', true
@@ -1086,6 +1102,7 @@ describe "Motions", ->
           expect(editor.getCursorBufferPosition()).toEqual [1, 0]
           keydown('n')
           expect(editor.getCursorBufferPosition()).toEqual [2, 0]
+          expect(atom.beep).not.toHaveBeenCalled()
 
         it "uses case sensitive search if useSmartcaseForSearch is true and searching uppercase", ->
           atom.config.set 'vim-mode.useSmartcaseForSearch', true
@@ -1093,6 +1110,7 @@ describe "Motions", ->
           expect(editor.getCursorBufferPosition()).toEqual [2, 0]
           keydown('n')
           expect(editor.getCursorBufferPosition()).toEqual [2, 0]
+          expect(atom.beep).not.toHaveBeenCalled()
 
       describe "repeating", ->
         it "does nothing with no search history", ->
@@ -1115,16 +1133,19 @@ describe "Motions", ->
           keydown('/')
           submitNormalModeInputText('')
           expect(editor.getCursorBufferPosition()).toEqual [3, 0]
+          expect(atom.beep).not.toHaveBeenCalled()
 
         it "repeats previous search with //", ->
           keydown('/')
           submitNormalModeInputText('/')
           expect(editor.getCursorBufferPosition()).toEqual [3, 0]
+          expect(atom.beep).not.toHaveBeenCalled()
 
         describe "the n keybinding", ->
           it "repeats the last search", ->
             keydown('n')
             expect(editor.getCursorBufferPosition()).toEqual [3, 0]
+            expect(atom.beep).not.toHaveBeenCalled()
 
         describe "the N keybinding", ->
           it "repeats the last search backwards", ->
@@ -1133,6 +1154,7 @@ describe "Motions", ->
             expect(editor.getCursorBufferPosition()).toEqual [3, 0]
             keydown('N', shift: true)
             expect(editor.getCursorBufferPosition()).toEqual [1, 0]
+            expect(atom.beep).not.toHaveBeenCalled()
 
       describe "composing", ->
         it "composes with operators", ->
@@ -1140,6 +1162,7 @@ describe "Motions", ->
           keydown('/')
           submitNormalModeInputText('def')
           expect(editor.getText()).toEqual "def\nabc\ndef\n"
+          expect(atom.beep).not.toHaveBeenCalled()
 
         it "repeats correctly with operators", ->
           keydown('d')
@@ -1148,12 +1171,14 @@ describe "Motions", ->
 
           keydown('.')
           expect(editor.getText()).toEqual "def\n"
+          expect(atom.beep).not.toHaveBeenCalled()
 
     describe "when reversed as ?", ->
       it "moves the cursor backwards to the specified search pattern", ->
         keydown('?')
         submitNormalModeInputText('def')
         expect(editor.getCursorBufferPosition()).toEqual [3, 0]
+        expect(atom.beep).not.toHaveBeenCalled()
 
       it "accepts / as a literal search pattern", ->
         editor.setText("abc\nd/f\nabc\nd/f\n")
@@ -1164,6 +1189,7 @@ describe "Motions", ->
         keydown('?')
         submitNormalModeInputText('/')
         expect(editor.getCursorBufferPosition()).toEqual [1, 1]
+        expect(atom.beep).not.toHaveBeenCalled()
 
       describe "repeating", ->
         beforeEach ->
@@ -1174,23 +1200,27 @@ describe "Motions", ->
           keydown('?')
           submitNormalModeInputText('')
           expect(editor.getCursorBufferPosition()).toEqual [1, 0]
+          expect(atom.beep).not.toHaveBeenCalled()
 
         it "repeats previous search as reversed with ??", ->
           keydown('?')
           submitNormalModeInputText('?')
           expect(editor.getCursorBufferPosition()).toEqual [1, 0]
+          expect(atom.beep).not.toHaveBeenCalled()
 
         describe 'the n keybinding', ->
           it "repeats the last search backwards", ->
             editor.setCursorBufferPosition([0, 0])
             keydown('n')
             expect(editor.getCursorBufferPosition()).toEqual [3, 0]
+            expect(atom.beep).not.toHaveBeenCalled()
 
         describe 'the N keybinding', ->
           it "repeats the last search forwards", ->
             editor.setCursorBufferPosition([0, 0])
             keydown('N', shift: true)
             expect(editor.getCursorBufferPosition()).toEqual [1, 0]
+            expect(atom.beep).not.toHaveBeenCalled()
 
     describe "using search history", ->
       inputEditor = null
@@ -1214,6 +1244,7 @@ describe "Motions", ->
         expect(inputEditor.getModel().getText()).toEqual('def')
         atom.commands.dispatch(inputEditor, 'core:move-up')
         expect(inputEditor.getModel().getText()).toEqual('def')
+        expect(atom.beep).not.toHaveBeenCalled()
 
       it "resets the search field to empty when scrolling back", ->
         keydown('/')
@@ -1225,6 +1256,7 @@ describe "Motions", ->
         expect(inputEditor.getModel().getText()).toEqual('abc')
         atom.commands.dispatch(inputEditor, 'core:move-down')
         expect(inputEditor.getModel().getText()).toEqual ''
+        expect(atom.beep).not.toHaveBeenCalled()
 
   describe "the * keybinding", ->
     beforeEach ->
@@ -1490,6 +1522,7 @@ describe "Motions", ->
       keydown('f')
       normalModeInputKeydown('d')
       expect(editor.getCursorScreenPosition()).toEqual [0, 0]
+      expect(atom.beep).not.toHaveBeenCalled()
 
     it "doesn't move if there aren't the specified count of the specified character", ->
       keydown('1')
@@ -1569,6 +1602,7 @@ describe "Motions", ->
       keydown('t')
       normalModeInputKeydown('d')
       expect(editor.getCursorScreenPosition()).toEqual [0, 0]
+      expect(atom.beep).not.toHaveBeenCalled()
 
     it "doesn't move if there aren't the specified count of the specified character", ->
       keydown('1')
@@ -1793,6 +1827,7 @@ describe "Motions", ->
         keydown(';')
         expect(editor.getCursorScreenPosition()).toEqual [0, 7]
         expect(otherEditor.getCursorScreenPosition()).toEqual [0, 5]
+        expect(atom.beep).not.toHaveBeenCalled()
 
   describe 'the % motion', ->
     beforeEach ->

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -1099,9 +1099,12 @@ describe "Motions", ->
           editor.setCursorBufferPosition([0, 0])
           keydown('n')
           expect(editor.getCursorBufferPosition()).toEqual [0, 0]
+          expect(atom.beep).toHaveBeenCalled()
+
           editor.setCursorBufferPosition([1, 1])
           keydown('n')
           expect(editor.getCursorBufferPosition()).toEqual [1, 1]
+          expect(atom.beep.callCount).toBe 2
 
       describe "repeating with search history", ->
         beforeEach ->

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -2007,18 +2007,21 @@ describe "Operators", ->
         keydown('a', ctrl: true)
         expect(editor.getCursorBufferPositions()).toEqual [[0, 2], [1, 3], [2, 4], [3, 3], [4, 0]]
         expect(editor.getText()).toBe '124\nab46\ncd-66ef\nab-4\na-bcdef'
+        expect(atom.beep).not.toHaveBeenCalled()
 
       it "repeats with .", ->
         keydown 'a', ctrl: true
         keydown '.'
         expect(editor.getCursorBufferPositions()).toEqual [[0, 2], [1, 3], [2, 4], [3, 3], [4, 0]]
         expect(editor.getText()).toBe '125\nab47\ncd-65ef\nab-3\na-bcdef'
+        expect(atom.beep).not.toHaveBeenCalled()
 
       it "can have a count", ->
         keydown '5'
         keydown 'a', ctrl: true
         expect(editor.getCursorBufferPositions()).toEqual [[0, 2], [1, 3], [2, 4], [3, 2], [4, 0]]
         expect(editor.getText()).toBe '128\nab50\ncd-62ef\nab0\na-bcdef'
+        expect(atom.beep).not.toHaveBeenCalled()
 
       it "can make a negative number positive, change number of digits", ->
         keydown '9'
@@ -2026,6 +2029,7 @@ describe "Operators", ->
         keydown 'a', ctrl: true
         expect(editor.getCursorBufferPositions()).toEqual [[0, 2], [1, 4], [2, 3], [3, 3], [4, 0]]
         expect(editor.getText()).toBe '222\nab144\ncd32ef\nab94\na-bcdef'
+        expect(atom.beep).not.toHaveBeenCalled()
 
       it "does nothing when cursor is after the number", ->
         editor.setCursorBufferPosition [2, 5]
@@ -2054,24 +2058,28 @@ describe "Operators", ->
         keydown('a', ctrl: true)
         expect(editor.getCursorBufferPositions()).toEqual [[0, 2], [1, 3], [2, 5], [3, 3], [4, 0]]
         expect(editor.getText()).toBe '124\nab46\ncd -66ef\nab-6\na-bcdef'
+        expect(atom.beep).not.toHaveBeenCalled()
 
     describe "decreasing numbers", ->
       it "decreases the next number", ->
         keydown('x', ctrl: true)
         expect(editor.getCursorBufferPositions()).toEqual [[0, 2], [1, 3], [2, 4], [3, 3], [4, 0]]
         expect(editor.getText()).toBe '122\nab44\ncd-68ef\nab-6\na-bcdef'
+        expect(atom.beep).not.toHaveBeenCalled()
 
       it "repeats with .", ->
         keydown 'x', ctrl: true
         keydown '.'
         expect(editor.getCursorBufferPositions()).toEqual [[0, 2], [1, 3], [2, 4], [3, 3], [4, 0]]
         expect(editor.getText()).toBe '121\nab43\ncd-69ef\nab-7\na-bcdef'
+        expect(atom.beep).not.toHaveBeenCalled()
 
       it "can have a count", ->
         keydown '5'
         keydown 'x', ctrl: true
         expect(editor.getCursorBufferPositions()).toEqual [[0, 2], [1, 3], [2, 4], [3, 4], [4, 0]]
         expect(editor.getText()).toBe '118\nab40\ncd-72ef\nab-10\na-bcdef'
+        expect(atom.beep).not.toHaveBeenCalled()
 
       it "can make a positive number negative, change number of digits", ->
         keydown '9'
@@ -2079,6 +2087,7 @@ describe "Operators", ->
         keydown 'x', ctrl: true
         expect(editor.getCursorBufferPositions()).toEqual [[0, 1], [1, 4], [2, 5], [3, 5], [4, 0]]
         expect(editor.getText()).toBe '24\nab-54\ncd-166ef\nab-104\na-bcdef'
+        expect(atom.beep).not.toHaveBeenCalled()
 
       it "does nothing when cursor is after the number", ->
         editor.setCursorBufferPosition [2, 5]
@@ -2107,6 +2116,7 @@ describe "Operators", ->
         keydown('x', ctrl: true)
         expect(editor.getCursorBufferPositions()).toEqual [[0, 2], [1, 3], [2, 5], [3, 3], [4, 0]]
         expect(editor.getText()).toBe '122\nab44\ncd -68ef\nab-4\na-bcdef'
+        expect(atom.beep).not.toHaveBeenCalled()
 
   describe 'the R keybinding', ->
     beforeEach ->

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -2032,6 +2032,7 @@ describe "Operators", ->
         keydown 'a', ctrl: true
         expect(editor.getCursorBufferPositions()).toEqual [[2, 5]]
         expect(editor.getText()).toBe '123\nab45\ncd-67ef\nab-5\na-bcdef'
+        expect(atom.beep).toHaveBeenCalled()
 
       it "does nothing on an empty line", ->
         editor.setText('\n')
@@ -2040,6 +2041,7 @@ describe "Operators", ->
         keydown 'a', ctrl: true
         expect(editor.getCursorBufferPositions()).toEqual [[0, 0], [1, 0]]
         expect(editor.getText()).toBe '\n'
+        expect(atom.beep).toHaveBeenCalled()
 
       it "honours the vim-mode:numberRegex setting", ->
         editor.setText('123\nab45\ncd -67ef\nab-5\na-bcdef')
@@ -2083,6 +2085,7 @@ describe "Operators", ->
         keydown 'x', ctrl: true
         expect(editor.getCursorBufferPositions()).toEqual [[2, 5]]
         expect(editor.getText()).toBe '123\nab45\ncd-67ef\nab-5\na-bcdef'
+        expect(atom.beep).toHaveBeenCalled()
 
       it "does nothing on an empty line", ->
         editor.setText('\n')
@@ -2091,6 +2094,7 @@ describe "Operators", ->
         keydown 'x', ctrl: true
         expect(editor.getCursorBufferPositions()).toEqual [[0, 0], [1, 0]]
         expect(editor.getText()).toBe '\n'
+        expect(atom.beep).toHaveBeenCalled()
 
       it "honours the vim-mode:numberRegex setting", ->
         editor.setText('123\nab45\ncd -67ef\nab-5\na-bcdef')

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -9,6 +9,7 @@ beforeEach ->
   atom.workspace ||= {}
   statusBarManager = null
   globalVimState = null
+  spyOn(atom, 'beep')
 
 getEditorElement = (callback) ->
   textEditor = null


### PR DESCRIPTION
Running specs shouldn’t beep if the beeps are expected. The patch contains commented code that, if uncommented, will print out messages when beep is called and not expected `toHaveBeenCalled()`.