### PR TITLE
Fix multi-cursor indent

### DIFF
--- a/lib/operators/indent-operators.coffee
+++ b/lib/operators/indent-operators.coffee
@@ -5,7 +5,7 @@ class AdjustIndentation extends Operator
   execute: (count=1) ->
     mode = @vimState.mode
     @motion.select(count)
-    {start} = @editor.getSelectedBufferRange()
+    originalRanges = @editor.getSelectedBufferRanges()
 
     if mode is 'visual'
       @editor.transact =>
@@ -13,7 +13,10 @@ class AdjustIndentation extends Operator
     else
       @indent()
 
-    @editor.setCursorBufferPosition([start.row, 0])
+    @editor.clearSelections()
+    @editor.getLastCursor().setBufferPosition([originalRanges.shift().start.row, 0])
+    for range in originalRanges
+      @editor.addCursorAtBufferPosition([range.start.row, 0])
     @editor.moveToFirstCharacterOfLine()
     @vimState.activateNormalMode()
 

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -1616,6 +1616,18 @@ describe "Operators", ->
           expect(editor.getText()).toBe "    12345\n    abcde\nABCDE"
           expect(editor.getSelectedBufferRanges()).toEqual [ [[0, 4], [0, 4]] ]
 
+    describe "with multiple selections", ->
+      beforeEach ->
+        editor.setCursorScreenPosition([1, 3])
+        keydown('v')
+        keydown('j')
+        editor.addCursorAtScreenPosition([0, 0])
+
+      it "indents the lines and keeps the cursors", ->
+        keydown('>')
+        expect(editor.getText()).toBe "  12345\n  abcde\n  ABCDE"
+        expect(editor.getCursorScreenPositions()).toEqual [[1, 2], [0, 2]]
+
   describe "the < keybinding", ->
     beforeEach ->
       editor.setText("    12345\n    abcde\nABCDE")


### PR DESCRIPTION
Indent, e.g. `>>`, should not collapse multiple cursors. This PR fixes it.

Here's steps to reproduce the problem:
 1. add a few cursors (e.g. with `cmd-click`)
 2. press `>>`, each line gets indented
 3. observe that cursors other than the last one are gone