### PR TITLE
Fix default counts

### DIFF
--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -334,7 +334,7 @@ class MoveToFirstCharacterOfLineAndDown extends Motion
   operatesLinewise: true
   operatesInclusively: true
 
-  moveCursor: (cursor, count=0) ->
+  moveCursor: (cursor, count=1) ->
     _.times count-1, ->
       cursor.moveDown()
     cursor.moveToBeginningOfLine()
@@ -413,7 +413,7 @@ class MoveToBottomOfScreen extends MoveToScreenLine
     lastScreenRow - offset
 
 class MoveToMiddleOfScreen extends MoveToScreenLine
-  getDestinationRow: (count) ->
+  getDestinationRow: ->
     firstScreenRow = @editorElement.getFirstVisibleScreenRow()
     lastScreenRow = @editorElement.getLastVisibleScreenRow()
     height = lastScreenRow - firstScreenRow
@@ -443,7 +443,7 @@ class ScrollKeepingCursor extends MoveToLine
     {row, column} = @editor.getCursorScreenPosition()
     @currentFirstScreenRow - @previousFirstScreenRow + row
 
-  scrollScreen: (count = 1) ->
+  scrollScreen: (count=1) ->
     @previousFirstScreenRow = @editorElement.getFirstVisibleScreenRow()
     destination = @scrollDestination(count)
     @editor.setScrollTop(destination)

--- a/lib/operators/general-operators.coffee
+++ b/lib/operators/general-operators.coffee
@@ -103,7 +103,7 @@ class Delete extends Operator
 class ToggleCase extends Operator
   constructor: (@editor, @vimState, {@complete}={}) ->
 
-  execute: (count=1) ->
+  execute: (count) ->
     if @motion?
       if _.contains(@motion.select(count), true)
         @editor.replaceSelectedText {}, (text) ->
@@ -119,7 +119,7 @@ class ToggleCase extends Operator
         for cursor in @editor.getCursors()
           point = cursor.getBufferPosition()
           lineLength = @editor.lineTextForBufferRow(point.row).length
-          cursorCount = Math.min(count, lineLength - point.column)
+          cursorCount = Math.min(count ? 1, lineLength - point.column)
 
           _.times cursorCount, =>
             point = cursor.getBufferPosition()
@@ -142,7 +142,7 @@ class UpperCase extends Operator
   constructor: (@editor, @vimState) ->
     @complete = false
 
-  execute: (count=1) ->
+  execute: (count) ->
     if _.contains(@motion.select(count), true)
       @editor.replaceSelectedText {}, (text) ->
         text.toUpperCase()
@@ -156,7 +156,7 @@ class LowerCase extends Operator
   constructor: (@editor, @vimState) ->
     @complete = false
 
-  execute: (count=1) ->
+  execute: (count) ->
     if _.contains(@motion.select(count), true)
       @editor.replaceSelectedText {}, (text) ->
         text.toLowerCase()

--- a/lib/operators/indent-operators.coffee
+++ b/lib/operators/indent-operators.coffee
@@ -2,14 +2,14 @@ _ = require 'underscore-plus'
 {Operator} = require './general-operators'
 
 class AdjustIndentation extends Operator
-  execute: (count=1) ->
+  execute: (count) ->
     mode = @vimState.mode
     @motion.select(count)
     originalRanges = @editor.getSelectedBufferRanges()
 
     if mode is 'visual'
       @editor.transact =>
-        _.times(count, => @indent())
+        _.times(count ? 1, => @indent())
     else
       @indent()
 

--- a/lib/operators/input.coffee
+++ b/lib/operators/input.coffee
@@ -66,7 +66,7 @@ class InsertAtBeginningOfLine extends Insert
     super
 
 class InsertAboveWithNewline extends Insert
-  execute: (count=1) ->
+  execute: ->
     @vimState.setInsertionCheckpoint() unless @typingCompleted
     @editor.insertNewlineAbove()
     @editor.getLastCursor().skipLeadingWhitespace()
@@ -81,7 +81,7 @@ class InsertAboveWithNewline extends Insert
     @typingCompleted = true
 
 class InsertBelowWithNewline extends Insert
-  execute: (count=1) ->
+  execute: ->
     @vimState.setInsertionCheckpoint() unless @typingCompleted
     @editor.insertNewlineBelow()
     @editor.getLastCursor().skipLeadingWhitespace()

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -1713,6 +1713,16 @@ describe "Operators", ->
         it "indents the current line", ->
           expect(editor.indentationForBufferRow(1)).toBe 0
 
+      describe "when followed by a G", ->
+        beforeEach ->
+          editor.setCursorScreenPosition([0, 0])
+          keydown('=')
+          keydown('G', shift: true)
+
+        it "uses the default count", ->
+          expect(editor.indentationForBufferRow(1)).toBe 0
+          expect(editor.indentationForBufferRow(2)).toBe 0
+
       describe "when followed by a repeating =", ->
         beforeEach ->
           keydown('2')
@@ -1859,6 +1869,13 @@ describe "Operators", ->
         keydown("l")
         expect(editor.getText()).toBe 'Abc\nXyZ'
 
+      it "uses default count", ->
+        editor.setCursorBufferPosition([0, 0])
+        keydown("g")
+        keydown("~")
+        keydown("G", shift: true)
+        expect(editor.getText()).toBe 'AbC\nxYz'
+
   describe 'the U keybinding', ->
     beforeEach ->
       editor.setText('aBc\nXyZ')
@@ -1882,6 +1899,13 @@ describe "Operators", ->
       expect(editor.getText()).toBe 'ABC\nXYZ'
       expect(editor.getCursorScreenPosition()).toEqual [1, 2]
 
+    it "uses default count", ->
+      editor.setCursorBufferPosition([0, 0])
+      keydown("g")
+      keydown("U", shift: true)
+      keydown("G", shift: true)
+      expect(editor.getText()).toBe 'ABC\nXYZ'
+
     it "makes the selected text uppercase in visual mode", ->
       keydown("V", shift: true)
       keydown("U", shift: true)
@@ -1898,6 +1922,13 @@ describe "Operators", ->
       keydown("$")
       expect(editor.getText()).toBe 'abc\nXyZ'
       expect(editor.getCursorScreenPosition()).toEqual [0, 2]
+
+    it "uses default count", ->
+      editor.setCursorBufferPosition([0, 0])
+      keydown("g")
+      keydown("u")
+      keydown("G", shift: true)
+      expect(editor.getText()).toBe 'abc\nxyz'
 
     it "makes the selected text lowercase in visual mode", ->
       keydown("V", shift: true)


### PR DESCRIPTION
Fixes #838.
The issue was that some operators (including `=`) had an unnecessary default `count` of 1, but the `G` motion is exceptional in that its default is different from 1. The specs never tested the combination of G with the offending operators, now they do.