### PR TITLE
really hide the hidden text editor

### DIFF
--- a/styles/vim-mode.less
+++ b/styles/vim-mode.less
@@ -13,15 +13,16 @@
   padding-left: 10px;
 }
 
-atom-panel.bottom.vim-hidden-normal-mode-input {
-  height: 1px;
-  width: 1px;
-  overflow: hidden;
-  border: none;
-  display: block;
-  position: fixed;
-  top: -1px;
-  left: -1px;
+.vim-hidden-normal-mode-input {
+  height: 0px !important;
+  width: 0px !important;
+  overflow: hidden !important;
+  border: none !important;
+  padding: 0 !important;
+  display: block !important;
+  position: fixed !important;
+  top: -10px !important;
+  left: -10px !important;
 }
 
 .block-cursor(@visibility: visible) {


### PR DESCRIPTION
I've noticed that in the evolution of #777, I forgot to update the style to match the new DOM structure. This fixes that and now the normal mode input element is truly hidden.