### PR TITLE
ignore input during IME composition in VimNormalModeInputElement

### DIFF
--- a/lib/view-models/vim-normal-mode-input-element.coffee
+++ b/lib/view-models/vim-normal-mode-input-element.coffee
@@ -28,8 +28,11 @@ class VimNormalModeInputElement extends HTMLDivElement
 
   handleEvents: ->
     if @singleChar?
+      compositing = false
       @editorElement.getModel().getBuffer().onDidChange (e) =>
-        @confirm() if e.newText
+        @confirm() if e.newText and not compositing
+      @editorElement.addEventListener 'compositionstart', -> compositing = true
+      @editorElement.addEventListener 'compositionend', -> compositing = false
     else
       atom.commands.add(@editorElement, 'editor:newline', @confirm.bind(this))
 

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -1807,6 +1807,34 @@ describe "Operators", ->
         normalModeInputKeydown('x')
         expect(editor.getCursorBufferPositions()).toEqual [[0, 0], [1, 0]]
 
+    describe 'with accented characters', ->
+      buildIMECompositionEvent = (event, {data, target}={}) ->
+        event = new Event(event)
+        event.data = data
+        Object.defineProperty(event, 'target', get: -> target)
+        event
+
+      buildTextInputEvent = ({data, target}) ->
+        event = new Event('textInput')
+        event.data = data
+        Object.defineProperty(event, 'target', get: -> target)
+        event
+
+      it 'works with IME composition', ->
+        keydown('r')
+        normalModeEditor = editor.normalModeInputView.editorElement
+        jasmine.attachToDOM(normalModeEditor)
+        domNode = normalModeEditor.component.domNode
+        inputNode = domNode.querySelector('.hidden-input')
+        domNode.dispatchEvent(buildIMECompositionEvent('compositionstart', target: inputNode))
+        domNode.dispatchEvent(buildIMECompositionEvent('compositionupdate', data: 's', target: inputNode))
+        expect(normalModeEditor.getModel().getText()).toEqual 's'
+        domNode.dispatchEvent(buildIMECompositionEvent('compositionupdate', data: 'sd', target: inputNode))
+        expect(normalModeEditor.getModel().getText()).toEqual 'sd'
+        domNode.dispatchEvent(buildIMECompositionEvent('compositionend', target: inputNode))
+        domNode.dispatchEvent(buildTextInputEvent(data: '速度', target: inputNode))
+        expect(editor.getText()).toBe '速度2\n速度4\n\n'
+
   describe 'the m keybinding', ->
     beforeEach ->
       editor.setText('12\n34\n56\n')


### PR DESCRIPTION
Fixes #791.
Adapted from [atom/autocomplete-plus](https://github.com/atom/autocomplete-plus/blob/90ae1f3ac5c2a7a46bacf3c1b7c891e1902aad42/lib/autocomplete-manager.coffee#L76)'s workaround for atom/atom#5414.
Specs adapted from atom/atom#8526 .