### PR TITLE
Atom undo for insert

### DIFF
--- a/lib/operators/input.coffee
+++ b/lib/operators/input.coffee
@@ -68,8 +68,9 @@ class InsertAtBeginningOfLine extends Insert
 class InsertAboveWithNewline extends Insert
   execute: (count=1) ->
     @vimState.setInsertionCheckpoint() unless @typingCompleted
-    @editor.insertNewlineAbove()
-    @editor.getLastCursor().skipLeadingWhitespace()
+    @editor.transact Infinity, =>
+      @editor.insertNewlineAbove()
+      @editor.getLastCursor().skipLeadingWhitespace()
 
     if @typingCompleted
       # We'll have captured the inserted newline, but we want to do that
@@ -83,8 +84,9 @@ class InsertAboveWithNewline extends Insert
 class InsertBelowWithNewline extends Insert
   execute: (count=1) ->
     @vimState.setInsertionCheckpoint() unless @typingCompleted
-    @editor.insertNewlineBelow()
-    @editor.getLastCursor().skipLeadingWhitespace()
+    @editor.transact Infinity, =>
+      @editor.insertNewlineBelow()
+      @editor.getLastCursor().skipLeadingWhitespace()
 
     if @typingCompleted
       # We'll have captured the inserted newline, but we want to do that
@@ -116,17 +118,18 @@ class Change extends Insert
       # undo transactions are already handled.
       @vimState.setInsertionCheckpoint() unless @typingCompleted
 
-      @setTextRegister(@register, @editor.getSelectedText())
-      if @motion.isLinewise?() and not @typingCompleted
-        for selection in @editor.getSelections()
-          if selection.getBufferRange().end.row is 0
+      @editor.transact Infinity, =>
+        @setTextRegister(@register, @editor.getSelectedText())
+        if @motion.isLinewise?() and not @typingCompleted
+          for selection in @editor.getSelections()
+            if selection.getBufferRange().end.row is 0
+              selection.deleteSelectedText()
+            else
+              selection.insertText("\n", autoIndent: true)
+            selection.cursor.moveLeft()
+        else
+          for selection in @editor.getSelections()
             selection.deleteSelectedText()
-          else
-            selection.insertText("\n", autoIndent: true)
-          selection.cursor.moveLeft()
-      else
-        for selection in @editor.getSelections()
-          selection.deleteSelectedText()
 
       return super if @typingCompleted
 

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -461,7 +461,10 @@ class VimState
     return unless @mode in [null, 'insert']
     @editorElement.component.setInputEnabled(false)
     @editorElement.classList.remove('replace-mode')
-    @editor.groupChangesSinceCheckpoint(@insertionCheckpoint)
+
+    # this empty transaction with 0 grouping interval makes sure undo doesn't group changes across here
+    @editor.transact 0, ->
+
     changes = getChangesSinceCheckpoint(@editor.buffer, @insertionCheckpoint)
     item = @inputOperator(@history[0])
     @insertionCheckpoint = null

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -249,7 +249,7 @@ describe "Operators", ->
       editor.setCursorScreenPosition([0, 0])
       keydown('3')
       keydown('s')
-      editor.insertText("ab")
+      editor.insertText("ab", groupUndo: true)
       keydown('escape')
       expect(editor.getText()).toBe 'ab345'
       keydown('u')
@@ -292,7 +292,7 @@ describe "Operators", ->
 
     it "is undoable", ->
       keydown('S', shift: true)
-      editor.insertText("abc")
+      editor.insertText("abc", groupUndo: true)
       keydown 'escape'
       expect(editor.getText()).toBe "12345\nabc\nABCDE"
       keydown 'u'
@@ -620,9 +620,9 @@ describe "Operators", ->
         it "is undoable", ->
           keydown('c')
           keydown('c')
-          editor.insertText("abc")
+          editor.insertText("def", groupUndo: true)
           keydown 'escape'
-          expect(editor.getText()).toBe "12345\n  abc\nABCDE"
+          expect(editor.getText()).toBe "12345\n  def\nABCDE"
           keydown 'u'
           expect(editor.getText()).toBe "12345\n  abcde\nABCDE"
           expect(editor.getSelectedText()).toBe ''
@@ -663,8 +663,7 @@ describe "Operators", ->
         expect(editor.getCursorScreenPosition()).toEqual [1, 0]
         expect(editorElement.classList.contains('insert-mode')).toBe(true)
 
-        # Just cannot get "typing" to work correctly in test.
-        editor.setText("12345\nfg\nABCDE")
+        editor.insertText("fg", groupUndo: true)
         keydown('escape')
         expect(editorElement.classList.contains('normal-mode')).toBe(true)
         expect(editor.getText()).toBe "12345\nfg\nABCDE"
@@ -717,7 +716,7 @@ describe "Operators", ->
           editor.addCursorAtScreenPosition([2, 1])
           keydown('c')
           keydown('%')
-          editor.insertText('x')
+          editor.insertText('x', groupUndo: true)
 
         it "replaces inclusively until matching bracket", ->
           expect(editor.getText()).toBe("1x8\naxe\nAxBCDE")
@@ -1395,7 +1394,7 @@ describe "Operators", ->
 
     it "is undoable", ->
       keydown('O', shift: true)
-      editor.insertText "def"
+      editor.insertText "def", groupUndo: true
       keydown 'escape'
       expect(editor.getText()).toBe "  abc\n  def\n  012\n"
       keydown 'u'
@@ -1434,7 +1433,7 @@ describe "Operators", ->
 
     it "is undoable", ->
       keydown('o')
-      editor.insertText "def"
+      editor.insertText "def", groupUndo: true
       keydown 'escape'
       expect(editor.getText()).toBe "abc\n  012\n  def\n"
       keydown 'u'
@@ -1912,16 +1911,17 @@ describe "Operators", ->
 
     it "allows undoing an entire batch of typing", ->
       keydown 'i'
-      editor.insertText("abcXX")
-      editor.backspace()
-      editor.backspace()
+      editor.insertText("abcXX", groupUndo: true)
+      # transact to enable grouping of changes, as is done in TextEditorElement
+      editor.transact 300, -> editor.backspace()
+      editor.transact 300, -> editor.backspace()
       keydown 'escape'
       expect(editor.getText()).toBe "abc123\nabc4567"
 
       keydown 'i'
-      editor.insertText "d"
-      editor.insertText "e"
-      editor.insertText "f"
+      editor.insertText "d", groupUndo: true
+      editor.insertText "e", groupUndo: true
+      editor.insertText "f", groupUndo: true
       keydown 'escape'
       expect(editor.getText()).toBe "abdefc123\nabdefc4567"
 


### PR DESCRIPTION
Alternative to #568 - instead of trying to emulate VIM's undo grouping (described [here](http://vimhelp.appspot.com/undo.txt.html) and [here](http://vimhelp.appspot.com/insert.txt.html#ins-special-special)) and running into difficulties trying to cover all the ways change groups should be interrupted (see #568), this one relies on Atom undo grouping, and attempts to join delete operations with subsequent typing.

Limitation: if you type `3sabc<escape>`, Atom will separate the undo of the deletion of three characters by `3s` and the addition of `a`. I have a solution in mind, a tentative PR for atom/text-buffer is in preparation.

@bronson - you commented on the desirability of #568 - can you please review this one?
