### PR TITLE
suppress unwanted bracket matching

### DIFF
--- a/lib/insert-mode.coffee
+++ b/lib/insert-mode.coffee
@@ -1,3 +1,4 @@
+# todo add specs with bracket-matcher for these two
 copyCharacterFromAbove = (editor, vimState) ->
   editor.transact ->
     for cursor in editor.getCursors()

--- a/lib/operators/input.coffee
+++ b/lib/operators/input.coffee
@@ -19,7 +19,8 @@ class Insert extends Operator
   execute: ->
     if @typingCompleted
       return unless @typedText? and @typedText.length > 0
-      @editor.insertText(@typedText, normalizeLineEndings: true, autoIndent: true)
+      # todo add specs with bracket-matcher for this
+      @editor.insertText(@typedText, normalizeLineEndings: true, autoIndent: true, matchBrackets: false)
       for cursor in @editor.getCursors()
         cursor.moveLeft() unless cursor.isAtBeginningOfLine()
     else
@@ -35,7 +36,8 @@ class ReplaceMode extends Insert
     if @typingCompleted
       return unless @typedText? and @typedText.length > 0
       @editor.transact =>
-        @editor.insertText(@typedText, normalizeLineEndings: true)
+        # todo add specs with bracket-matcher for this
+        @editor.insertText(@typedText, normalizeLineEndings: true, matchBrackets: false)
         toDelete = @typedText.length - @countChars('\n', @typedText)
         for selection in @editor.getSelections()
           count = toDelete

--- a/lib/operators/put-operator.coffee
+++ b/lib/operators/put-operator.coffee
@@ -52,7 +52,8 @@ class Put extends Operator
         @editor.moveToBeginningOfLine()
         originalPosition = @editor.getCursorScreenPosition()
 
-    @editor.insertText(textToInsert)
+    # todo add specs with bracket-matcher for this
+    @editor.insertText(textToInsert, matchBrackets: false)
 
     if originalPosition?
       @editor.setCursorScreenPosition(originalPosition)

--- a/lib/operators/replace-operator.coffee
+++ b/lib/operators/replace-operator.coffee
@@ -20,6 +20,7 @@ class Replace extends OperatorWithInput
 
       return
 
+    # todo add specs with bracket matcher, for both editor.replaceSelectedText and editor.setTextInBufferRange
     @editor.transact =>
       if @motion?
         if _.contains(@motion.select(), true)

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -37,6 +37,13 @@ class VimState
         if e.target is @editorElement
           @checkSelections()
 
+    # suppress bracket matching in replace mode
+    # todo add bracket matcher specs for this
+    # FIXME: this doesn't get removed should vim-mode be deactivated
+    _.adviseBefore @editor, 'insertText', (text, options) =>
+      options?.matchBrackets = false if @mode is 'insert' and @submode is 'replace'
+      return true
+
     @editorElement.classList.add("vim-mode")
     @setupNormalMode()
     if settings.startInInsertMode()
@@ -648,7 +655,8 @@ class VimState
   # Returns nothing.
   insertRegister: (name) ->
     text = @getRegister(name)?.text
-    @editor.insertText(text) if text?
+    # todo add specs with bracket-matcher for this
+    @editor.insertText(text, groupUndo: true, matchBrackets: false) if text?
 
   # Private: ensure the mode follows the state of selections
   checkSelections: =>

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -37,13 +37,6 @@ class VimState
         if e.target is @editorElement
           @checkSelections()
 
-    # suppress bracket matching in replace mode
-    # todo add bracket matcher specs for this
-    # FIXME: this doesn't get removed should vim-mode be deactivated
-    _.adviseBefore @editor, 'insertText', (text, options) =>
-      options?.matchBrackets = false if @mode is 'insert' and @submode is 'replace'
-      return true
-
     @editorElement.classList.add("vim-mode")
     @setupNormalMode()
     if settings.startInInsertMode()
@@ -430,6 +423,13 @@ class VimState
     @editorElement.classList.add('replace-mode')
     @subscriptions.add @replaceModeListener = @editor.onWillInsertText @replaceModeInsertHandler
     @subscriptions.add @replaceModeUndoListener = @editor.onDidInsertText @replaceModeUndoHandler
+
+    # todo add bracket matcher specs for replace mode
+    if @replaceModeBracketMatcherGuard ?= atom.packages.getActivePackage('bracket-matcher')
+      # suppress bracket matching in replace mode
+      _.adviseBefore @editor, 'insertText', (text, options) =>
+        options?.matchBrackets = false if not @destroyed and @mode is 'insert' and @submode is 'replace'
+        return true
 
   replaceModeInsertHandler: (event) =>
     chars = event.text?.split('') or []


### PR DESCRIPTION
Fixes #792, but depends on atom/bracket-matcher#176.

You'll notice that there's a lot of _to-do_s for specs which I'll be happy to add once this whole approach is approved.

To do:
- [ ] get atom/bracket-matcher#176 merged
- [ ] add specs
