### PR TITLE
Made clause about international keyboards specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ wasn't built in a day).
 If you want the vim ex line (for `:w`, `:s`, etc.), you can try [ex-mode](https://atom.io/packages/ex-mode)
 which works in conjuction with this plugin.
 
-Currently, vim-mode has some issues with international keyboard layouts.
+Currently, vim-mode has some issues with non-US keyboard layouts. If you are using a keyboard layout which *isn't* American and having problems, try installing [keyboard-localization](https://atom.io/packages/keyboard-localization).
 
 If there's a feature of Vim you're missing, it might just be that you use it
 more often than other developers. Adding a feature can be quick and easy. Check


### PR DESCRIPTION
**Proposed changes:**

- The text used to read *"vim-mode has some issues with international keyboard layouts"*. The *"International"* part was too general in my opinion, so I changed it to *"non-US"* which - [in my experience](https://github.com/atom/vim-mode/issues/853) - is true.
- A solution which worked really well for *me* was to install [*keyboard-localization*](https://atom.io/packages/keyboard-localization). I *imagine* more people will find it useful - could be a good idea to mention it.

**Other:**

- When I read *"international"* I thought of countries whose native language isn't English (e.g. France and Turkey). I *definitely* thought UK and US were similar enough but it turns out UK is different enough to cause problems. I imagine that other people in the UK could get confused by this. *Maybe* it would be a good idea to update the text to specify this explicitly e.g.:

> Currently, vim-mode has some issues with non-US keyboard layouts (*including* UK keyboard layouts).

