### PR TITLE
Fix jump-to-nearest for quotes text objects

### DIFF
--- a/lib/text-objects.coffee
+++ b/lib/text-objects.coffee
@@ -88,7 +88,7 @@ class SelectInsideQuotes extends TextObject
         ++ start.column # skip the opening quote
         end = @findClosingQuote(start)
         if end?
-          selection.setBufferRange(mergeRanges(selection.getBufferRange(), [start, end]))
+          selection.setBufferRange([start, end])
       not selection.isEmpty()
 
 # SelectInsideBrackets and the previous class defined (SelectInsideQuotes) are

--- a/spec/text-objects-spec.coffee
+++ b/spec/text-objects-spec.coffee
@@ -453,17 +453,13 @@ describe "TextObjects", ->
       expect(editorElement.classList.contains('operator-pending-mode')).toBe(false)
       expect(editorElement.classList.contains('normal-mode')).toBe(true)
 
-    it "expands an existing selection in visual mode", ->
-      editor.setCursorScreenPosition([0, 25])
+    it 'selects inside the nearest string', ->
+      editor.setText('var a = \'awesome string\'')
+      editor.setCursorScreenPosition([0, 0])
       keydown('v')
-      keydown('l')
-      keydown('l')
-      keydown('l')
-      keydown('l')
       keydown('i')
       keydown('\'')
-
-      expect(editor.getSelectedScreenRange()).toEqual [[0, 25], [0, 34]]
+      expect(editor.getSelectedScreenRange()).toEqual [[0, 9], [0, 23]]
 
   describe "the 'i\"' text object", ->
     beforeEach ->
@@ -498,17 +494,13 @@ describe "TextObjects", ->
       expect(editor.getCursorScreenPosition()).toEqual [0, 39]
       expect(editorElement.classList.contains('operator-pending-mode')).toBe(false)
 
-    it "expands an existing selection in visual mode", ->
-      editor.setCursorScreenPosition([0, 25])
+    it 'selects inside the nearest string', ->
+      editor.setText('var a = "awesome string"')
+      editor.setCursorScreenPosition([0, 0])
       keydown('v')
-      keydown('l')
-      keydown('l')
-      keydown('l')
-      keydown('l')
       keydown('i')
       keydown('"')
-
-      expect(editor.getSelectedScreenRange()).toEqual [[0, 25], [0, 34]]
+      expect(editor.getSelectedScreenRange()).toEqual [[0, 9], [0, 23]]
 
   describe "the 'aw' text object", ->
     beforeEach ->
@@ -776,17 +768,13 @@ describe "TextObjects", ->
       expect(editorElement.classList.contains('operator-pending-mode')).toBe(false)
       expect(editorElement.classList.contains('normal-mode')).toBe(true)
 
-    it "expands an existing selection in visual mode", ->
-      editor.setCursorScreenPosition([0, 25])
+    it 'selects around the nearest string', ->
+      editor.setText('var a = \'awesome string\'')
+      editor.setCursorScreenPosition([0, 0])
       keydown('v')
-      keydown('l')
-      keydown('l')
-      keydown('l')
-      keydown('l')
       keydown('a')
       keydown('\'')
-
-      expect(editor.getSelectedScreenRange()).toEqual [[0, 25], [0, 35]]
+      expect(editor.getSelectedScreenRange()).toEqual [[0, 8], [0, 24]]
 
   describe "the 'a\"' text object", ->
     beforeEach ->
@@ -812,14 +800,10 @@ describe "TextObjects", ->
       expect(editorElement.classList.contains('operator-pending-mode')).toBe(false)
       expect(editorElement.classList.contains('normal-mode')).toBe(true)
 
-    it "expands an existing selection in visual mode", ->
-      editor.setCursorScreenPosition([0, 25])
+    it 'selects around the nearest string', ->
+      editor.setText('var a = "awesome string"')
+      editor.setCursorScreenPosition([0, 0])
       keydown('v')
-      keydown('l')
-      keydown('l')
-      keydown('l')
-      keydown('l')
       keydown('a')
       keydown('"')
-
-      expect(editor.getSelectedScreenRange()).toEqual [[0, 25], [0, 35]]
+      expect(editor.getSelectedScreenRange()).toEqual [[0, 8], [0, 24]]


### PR DESCRIPTION
This is a fix for #872.

I couldn't think of a way to distinguish between when we want to merge selections and when we want to jump-to-nearest. So, I just removed the call to mergeRanges, and replaced the tests that expected the ranges to be merged.
