### PR TITLE
Fix deprecated methods

### DIFF
--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -431,12 +431,12 @@ class ScrollKeepingCursor extends MoveToLine
   select: (count, options) ->
     finalDestination = @scrollScreen(count)
     super(count, options)
-    @editor.setScrollTop(finalDestination)
+    @editorElement.setScrollTop(finalDestination)
 
   execute: (count) ->
     finalDestination = @scrollScreen(count)
     super(count)
-    @editor.setScrollTop(finalDestination)
+    @editorElement.setScrollTop(finalDestination)
 
   moveCursor: (cursor, count=1) ->
     cursor.setScreenPosition([@getDestinationRow(count), 0])
@@ -448,27 +448,27 @@ class ScrollKeepingCursor extends MoveToLine
   scrollScreen: (count=1) ->
     @previousFirstScreenRow = @editorElement.getFirstVisibleScreenRow()
     destination = @scrollDestination(count)
-    @editor.setScrollTop(destination)
+    @editorElement.setScrollTop(destination)
     @currentFirstScreenRow = @editorElement.getFirstVisibleScreenRow()
     destination
 
 class ScrollHalfUpKeepCursor extends ScrollKeepingCursor
   scrollDestination: (count) ->
     half = (Math.floor(@editor.getRowsPerPage() / 2) * @editor.getLineHeightInPixels())
-    @editor.getScrollTop() - count * half
+    @editorElement.getScrollTop() - count * half
 
 class ScrollFullUpKeepCursor extends ScrollKeepingCursor
   scrollDestination: (count) ->
-    @editor.getScrollTop() - (count * @editor.getHeight())
+    @editorElement.getScrollTop() - (count * @editorElement.getHeight())
 
 class ScrollHalfDownKeepCursor extends ScrollKeepingCursor
   scrollDestination: (count) ->
     half = (Math.floor(@editor.getRowsPerPage() / 2) * @editor.getLineHeightInPixels())
-    @editor.getScrollTop() + count * half
+    @editorElement.getScrollTop() + count * half
 
 class ScrollFullDownKeepCursor extends ScrollKeepingCursor
   scrollDestination: (count) ->
-    @editor.getScrollTop() + (count * @editor.getHeight())
+    @editorElement.getScrollTop() + (count * @editorElement.getHeight())
 
 module.exports = {
   Motion, MotionWithInput, CurrentSelection, MoveLeft, MoveRight, MoveUp, MoveDown,

--- a/lib/operators/general-operators.coffee
+++ b/lib/operators/general-operators.coffee
@@ -170,6 +170,7 @@ class Yank extends Operator
   register: null
 
   constructor: (@editor, @vimState) ->
+    @editorElement = atom.views.getView(@editor)
     @register = settings.defaultRegister()
 
   # Public: Copies the text selected by the given motion.
@@ -178,8 +179,8 @@ class Yank extends Operator
   #
   # Returns nothing.
   execute: (count) ->
-    oldTop = @editor.getScrollTop()
-    oldLeft = @editor.getScrollLeft()
+    oldTop = @editorElement.getScrollTop()
+    oldLeft = @editorElement.getScrollLeft()
     oldLastCursorPosition = @editor.getCursorBufferPosition()
 
     originalPositions = @editor.getCursorBufferPositions()
@@ -203,8 +204,8 @@ class Yank extends Operator
     @editor.setSelectedBufferRanges(newPositions.map (p) -> new Range(p, p))
 
     if oldLastCursorPosition.isEqual(@editor.getCursorBufferPosition())
-      @editor.setScrollLeft(oldLeft)
-      @editor.setScrollTop(oldTop)
+      @editorElement.setScrollLeft(oldLeft)
+      @editorElement.setScrollTop(oldTop)
 
     @vimState.activateNormalMode()
 

--- a/lib/scroll.coffee
+++ b/lib/scroll.coffee
@@ -53,7 +53,7 @@ class ScrollCursorToTop extends ScrollCursor
   scrollUp: ->
     return if @rows.last is @rows.final
     @pixel -= (@editor.getLineHeightInPixels() * @scrolloff)
-    @editor.setScrollTop(@pixel)
+    @editorElement.setScrollTop(@pixel)
 
   moveToFirstNonBlank: ->
     @editor.moveToFirstCharacterOfLine()
@@ -64,8 +64,8 @@ class ScrollCursorToMiddle extends ScrollCursor
     @scrollMiddle()
 
   scrollMiddle: ->
-    @pixel -= (@editor.getHeight() / 2)
-    @editor.setScrollTop(@pixel)
+    @pixel -= (@editorElement.getHeight() / 2)
+    @editorElement.setScrollTop(@pixel)
 
   moveToFirstNonBlank: ->
     @editor.moveToFirstCharacterOfLine()
@@ -78,8 +78,8 @@ class ScrollCursorToBottom extends ScrollCursor
   scrollDown: ->
     return if @rows.first is 0
     offset = (@editor.getLineHeightInPixels() * (@scrolloff + 1))
-    @pixel -= (@editor.getHeight() - offset)
-    @editor.setScrollTop(@pixel)
+    @pixel -= (@editorElement.getHeight() - offset)
+    @editorElement.setScrollTop(@pixel)
 
   moveToFirstNonBlank: ->
     @editor.moveToFirstCharacterOfLine()
@@ -98,12 +98,12 @@ class ScrollHorizontal
 
 class ScrollCursorToLeft extends ScrollHorizontal
   execute: ->
-    @editor.setScrollLeft(@pixel)
+    @editorElement.setScrollLeft(@pixel)
     @putCursorOnScreen()
 
 class ScrollCursorToRight extends ScrollHorizontal
   execute: ->
-    @editor.setScrollRight(@pixel)
+    @editorElement.setScrollRight(@pixel)
     @putCursorOnScreen()
 
 module.exports = {ScrollDown, ScrollUp, ScrollCursorToTop, ScrollCursorToMiddle,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "repository": "https://github.com/atom/vim-mode",
   "engines": {
-    "atom": ">0.151.0"
+    "atom": ">=1.1.0"
   },
   "dependencies": {
     "event-kit": "^0.7.2",

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -1,7 +1,7 @@
 helpers = require './spec-helper'
 
 describe "Motions", ->
-  [editor, editorElement, vimState] = []
+  [editor, editorElement, parentElement, vimState] = []
 
   beforeEach ->
     vimMode = atom.packages.loadPackage('vim-mode')
@@ -1378,17 +1378,17 @@ describe "Motions", ->
       spyOn(editor.getLastCursor(), 'setScreenPosition')
 
     it "moves the cursor to the first row if visible", ->
-      spyOn(editor, 'getFirstVisibleScreenRow').andReturn(0)
+      spyOn(editorElement, 'getFirstVisibleScreenRow').andReturn(0)
       keydown('H', shift: true)
       expect(editor.getLastCursor().setScreenPosition).toHaveBeenCalledWith([0, 0])
 
     it "moves the cursor to the first visible row plus offset", ->
-      spyOn(editor, 'getFirstVisibleScreenRow').andReturn(2)
+      spyOn(editorElement, 'getFirstVisibleScreenRow').andReturn(2)
       keydown('H', shift: true)
       expect(editor.getLastCursor().setScreenPosition).toHaveBeenCalledWith([4, 0])
 
     it "respects counts", ->
-      spyOn(editor, 'getFirstVisibleScreenRow').andReturn(0)
+      spyOn(editorElement, 'getFirstVisibleScreenRow').andReturn(0)
       keydown('3')
       keydown('H', shift: true)
       expect(editor.getLastCursor().setScreenPosition).toHaveBeenCalledWith([2, 0])
@@ -1400,17 +1400,17 @@ describe "Motions", ->
       spyOn(editor.getLastCursor(), 'setScreenPosition')
 
     it "moves the cursor to the first row if visible", ->
-      spyOn(editor, 'getLastVisibleScreenRow').andReturn(10)
+      spyOn(editorElement, 'getLastVisibleScreenRow').andReturn(10)
       keydown('L', shift: true)
       expect(editor.getLastCursor().setScreenPosition).toHaveBeenCalledWith([10, 0])
 
     it "moves the cursor to the first visible row plus offset", ->
-      spyOn(editor, 'getLastVisibleScreenRow').andReturn(6)
+      spyOn(editorElement, 'getLastVisibleScreenRow').andReturn(6)
       keydown('L', shift: true)
       expect(editor.getLastCursor().setScreenPosition).toHaveBeenCalledWith([4, 0])
 
     it "respects counts", ->
-      spyOn(editor, 'getLastVisibleScreenRow').andReturn(10)
+      spyOn(editorElement, 'getLastVisibleScreenRow').andReturn(10)
       keydown('3')
       keydown('L', shift: true)
       expect(editor.getLastCursor().setScreenPosition).toHaveBeenCalledWith([8, 0])
@@ -1420,8 +1420,8 @@ describe "Motions", ->
       editor.setText("1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n")
       editor.setCursorScreenPosition([8, 0])
       spyOn(editor.getLastCursor(), 'setScreenPosition')
-      spyOn(editor, 'getLastVisibleScreenRow').andReturn(10)
-      spyOn(editor, 'getFirstVisibleScreenRow').andReturn(0)
+      spyOn(editorElement, 'getLastVisibleScreenRow').andReturn(10)
+      spyOn(editorElement, 'getFirstVisibleScreenRow').andReturn(0)
 
     it "moves the cursor to the first row if visible", ->
       keydown('M', shift: true)
@@ -1920,16 +1920,21 @@ describe "Motions", ->
 
   describe "scrolling screen and keeping cursor in the same screen position", ->
     beforeEach ->
+      jasmine.attachToDOM(editorElement)
+
       editor.setText([0...80].join("\n"))
-      editor.setHeight(20 * 10)
-      editor.setLineHeightInPixels(10)
-      editor.setScrollTop(40 * 10)
+
+      editorElement.setHeight(20 * 10)
+      editorElement.style.lineHeight = "10px"
+      atom.views.performDocumentPoll()
+
+      editorElement.setScrollTop(40 * 10)
       editor.setCursorBufferPosition([42, 0])
 
     describe "the ctrl-u keybinding", ->
       it "moves the screen down by half screen size and keeps cursor onscreen", ->
         keydown('u', ctrl: true)
-        expect(editor.getScrollTop()).toEqual 300
+        expect(editorElement.getScrollTop()).toEqual 300
         expect(editor.getCursorBufferPosition()).toEqual [32, 0]
 
       it "selects on visual mode", ->
@@ -1946,7 +1951,7 @@ describe "Motions", ->
     describe "the ctrl-b keybinding", ->
       it "moves screen up one page", ->
         keydown('b', ctrl: true)
-        expect(editor.getScrollTop()).toEqual 200
+        expect(editorElement.getScrollTop()).toEqual 200
         expect(editor.getCursorScreenPosition()).toEqual [22, 0]
 
       it "selects on visual mode", ->
@@ -1964,7 +1969,7 @@ describe "Motions", ->
     describe "the ctrl-d keybinding", ->
       it "moves the screen down by half screen size and keeps cursor onscreen", ->
         keydown('d', ctrl: true)
-        expect(editor.getScrollTop()).toEqual 500
+        expect(editorElement.getScrollTop()).toEqual 500
         expect(editor.getCursorBufferPosition()).toEqual [52, 0]
 
       it "selects on visual mode", ->
@@ -1981,7 +1986,7 @@ describe "Motions", ->
     describe "the ctrl-f keybinding", ->
       it "moves screen down one page", ->
         keydown('f', ctrl: true)
-        expect(editor.getScrollTop()).toEqual 600
+        expect(editorElement.getScrollTop()).toEqual 600
         expect(editor.getCursorScreenPosition()).toEqual [62, 0]
 
       it "selects on visual mode", ->

--- a/spec/operators-spec.coffee
+++ b/spec/operators-spec.coffee
@@ -1131,9 +1131,12 @@ describe "Operators", ->
 
     describe "in a long file", ->
       beforeEach ->
-        editor.setHeight(400)
-        editor.setLineHeightInPixels(10)
-        editor.setDefaultCharWidth(10)
+        jasmine.attachToDOM(editorElement)
+        editorElement.setHeight(400)
+        editorElement.style.lineHeight = "10px"
+        editorElement.style.font = "16px monospace"
+        atom.views.performDocumentPoll()
+
         text = ""
         for i in [1..200]
           text += "#{i}\n"
@@ -1142,7 +1145,7 @@ describe "Operators", ->
       describe "yanking many lines forward", ->
         it "does not scroll the window", ->
           editor.setCursorBufferPosition [40, 1]
-          previousScrollTop = editor.getScrollTop()
+          previousScrollTop = editorElement.getScrollTop()
 
           # yank many lines
           keydown('y')
@@ -1151,14 +1154,14 @@ describe "Operators", ->
           keydown('0')
           keydown('G', shift: true)
 
-          expect(editor.getScrollTop()).toEqual(previousScrollTop)
+          expect(editorElement.getScrollTop()).toEqual(previousScrollTop)
           expect(editor.getCursorBufferPosition()).toEqual [40, 1]
           expect(vimState.getRegister('"').text.split('\n').length).toBe 121
 
       describe "yanking many lines backwards", ->
         it "scrolls the window", ->
           editor.setCursorBufferPosition [140, 1]
-          previousScrollTop = editor.getScrollTop()
+          previousScrollTop = editorElement.getScrollTop()
 
           # yank many lines
           keydown('y')
@@ -1166,7 +1169,7 @@ describe "Operators", ->
           keydown('0')
           keydown('G', shift: true)
 
-          expect(editor.getScrollTop()).toNotEqual previousScrollTop
+          expect(editorElement.getScrollTop()).toNotEqual previousScrollTop
           expect(editor.getCursorBufferPosition()).toEqual [59, 1]
           expect(vimState.getRegister('"').text.split('\n').length).toBe 83
 

--- a/spec/scroll-spec.coffee
+++ b/spec/scroll-spec.coffee
@@ -13,6 +13,7 @@ describe "Scrolling", ->
       vimState = editorElement.vimState
       vimState.activateNormalMode()
       vimState.resetNormalMode()
+      jasmine.attachToDOM(element)
 
   keydown = (key, options={}) ->
     options.element ?= editorElement
@@ -21,8 +22,8 @@ describe "Scrolling", ->
   describe "scrolling keybindings", ->
     beforeEach ->
       editor.setText("1\n2\n3\n4\n5\n6\n7\n8\n9\n10")
-      spyOn(editor, 'getFirstVisibleScreenRow').andReturn(2)
-      spyOn(editor, 'getLastVisibleScreenRow').andReturn(8)
+      spyOn(editorElement, 'getFirstVisibleScreenRow').andReturn(2)
+      spyOn(editorElement, 'getLastVisibleScreenRow').andReturn(8)
       spyOn(editor, 'scrollToScreenPosition')
 
     describe "the ctrl-e keybinding", ->
@@ -53,79 +54,83 @@ describe "Scrolling", ->
       editor.setText(text)
 
       spyOn(editor, 'moveToFirstCharacterOfLine')
-      spyOn(editor, 'getLineHeightInPixels').andReturn(20)
-      spyOn(editor, 'setScrollTop')
-      spyOn(editor, 'getHeight').andReturn(200)
-      spyOn(editor, 'getFirstVisibleScreenRow').andReturn(90)
-      spyOn(editor, 'getLastVisibleScreenRow').andReturn(110)
+
+      spyOn(editorElement, 'setScrollTop')
+      editorElement.style.lineHeight = "20px"
+      editorElement.component.sampleFontStyling()
+      editorElement.setHeight(200)
+      spyOn(editorElement, 'getFirstVisibleScreenRow').andReturn(90)
+      spyOn(editorElement, 'getLastVisibleScreenRow').andReturn(110)
 
     describe "the z<CR> keybinding", ->
       keydownCodeForEnter = '\r'
 
       beforeEach ->
-        spyOn(editor, 'pixelPositionForScreenPosition').andReturn({top: 1000, left: 0})
+        spyOn(editorElement, 'pixelPositionForScreenPosition').andReturn({top: 1000, left: 0})
 
       it "moves the screen to position cursor at the top of the window and moves cursor to first non-blank in the line", ->
         keydown('z')
         keydown(keydownCodeForEnter)
-        expect(editor.setScrollTop).toHaveBeenCalledWith(960)
+        expect(editorElement.setScrollTop).toHaveBeenCalledWith(960)
         expect(editor.moveToFirstCharacterOfLine).toHaveBeenCalled()
 
     describe "the zt keybinding", ->
       beforeEach ->
-        spyOn(editor, 'pixelPositionForScreenPosition').andReturn({top: 1000, left: 0})
+        spyOn(editorElement, 'pixelPositionForScreenPosition').andReturn({top: 1000, left: 0})
 
       it "moves the screen to position cursor at the top of the window and leave cursor in the same column", ->
         keydown('z')
         keydown('t')
-        expect(editor.setScrollTop).toHaveBeenCalledWith(960)
+        expect(editorElement.setScrollTop).toHaveBeenCalledWith(960)
         expect(editor.moveToFirstCharacterOfLine).not.toHaveBeenCalled()
 
     describe "the z. keybinding", ->
       beforeEach ->
-        spyOn(editor, 'pixelPositionForScreenPosition').andReturn({top: 1000, left: 0})
+        spyOn(editorElement, 'pixelPositionForScreenPosition').andReturn({top: 1000, left: 0})
 
       it "moves the screen to position cursor at the center of the window and moves cursor to first non-blank in the line", ->
         keydown('z')
         keydown('.')
-        expect(editor.setScrollTop).toHaveBeenCalledWith(900)
+        expect(editorElement.setScrollTop).toHaveBeenCalledWith(900)
         expect(editor.moveToFirstCharacterOfLine).toHaveBeenCalled()
 
     describe "the zz keybinding", ->
       beforeEach ->
-        spyOn(editor, 'pixelPositionForScreenPosition').andReturn({top: 1000, left: 0})
+        spyOn(editorElement, 'pixelPositionForScreenPosition').andReturn({top: 1000, left: 0})
 
       it "moves the screen to position cursor at the center of the window and leave cursor in the same column", ->
         keydown('z')
         keydown('z')
-        expect(editor.setScrollTop).toHaveBeenCalledWith(900)
+        expect(editorElement.setScrollTop).toHaveBeenCalledWith(900)
         expect(editor.moveToFirstCharacterOfLine).not.toHaveBeenCalled()
 
     describe "the z- keybinding", ->
       beforeEach ->
-        spyOn(editor, 'pixelPositionForScreenPosition').andReturn({top: 1000, left: 0})
+        spyOn(editorElement, 'pixelPositionForScreenPosition').andReturn({top: 1000, left: 0})
 
       it "moves the screen to position cursor at the bottom of the window and moves cursor to first non-blank in the line", ->
         keydown('z')
         keydown('-')
-        expect(editor.setScrollTop).toHaveBeenCalledWith(860)
+        expect(editorElement.setScrollTop).toHaveBeenCalledWith(860)
         expect(editor.moveToFirstCharacterOfLine).toHaveBeenCalled()
 
     describe "the zb keybinding", ->
       beforeEach ->
-        spyOn(editor, 'pixelPositionForScreenPosition').andReturn({top: 1000, left: 0})
+        spyOn(editorElement, 'pixelPositionForScreenPosition').andReturn({top: 1000, left: 0})
 
       it "moves the screen to position cursor at the bottom of the window and leave cursor in the same column", ->
         keydown('z')
         keydown('b')
-        expect(editor.setScrollTop).toHaveBeenCalledWith(860)
+        expect(editorElement.setScrollTop).toHaveBeenCalledWith(860)
         expect(editor.moveToFirstCharacterOfLine).not.toHaveBeenCalled()
 
   describe "horizontal scroll cursor keybindings", ->
     beforeEach ->
-      editor.setWidth(600)
-      editor.setLineHeightInPixels(10)
-      editor.setDefaultCharWidth(10)
+      editorElement.setWidth(600)
+      editorElement.setHeight(600)
+      editorElement.style.lineHeight = "10px"
+      editorElement.style.font = "16px monospace"
+      atom.views.performDocumentPoll()
       text = ""
       for i in [100..199]
         text += "#{i} "
@@ -137,12 +142,12 @@ describe "Scrolling", ->
         editor.setCursorBufferPosition([0, pos])
         keydown('z')
         keydown('s')
-        editor.getScrollLeft()
+        editorElement.getScrollLeft()
 
       startPosition = NaN
 
       beforeEach ->
-        startPosition = editor.getScrollLeft()
+        startPosition = editorElement.getScrollLeft()
 
       it "does nothing near the start of the line", ->
         pos1 = zsPos(1)
@@ -170,7 +175,7 @@ describe "Scrolling", ->
 
       it "does nothing if all lines are short", ->
         editor.setText('short')
-        startPosition = editor.getScrollLeft()
+        startPosition = editorElement.getScrollLeft()
         pos1 = zsPos(1)
         expect(pos1).toEqual(startPosition)
         expect(editor.getCursorBufferPosition()).toEqual [0, 1]
@@ -184,12 +189,12 @@ describe "Scrolling", ->
         editor.setCursorBufferPosition([0, pos])
         keydown('z')
         keydown('e')
-        editor.getScrollLeft()
+        editorElement.getScrollLeft()
 
       startPosition = NaN
 
       beforeEach ->
-        startPosition = editor.getScrollLeft()
+        startPosition = editorElement.getScrollLeft()
 
       it "does nothing near the start of the line", ->
         pos1 = zePos(1)
@@ -221,7 +226,7 @@ describe "Scrolling", ->
 
       it "does nothing if all lines are short", ->
         editor.setText('short')
-        startPosition = editor.getScrollLeft()
+        startPosition = editorElement.getScrollLeft()
         pos1 = zePos(1)
         expect(pos1).toEqual(startPosition)
         expect(editor.getCursorBufferPosition()).toEqual [0, 1]

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -19,8 +19,8 @@ getEditorElement = (callback) ->
       textEditor = e
 
   runs ->
-    element = document.createElement("atom-text-editor")
-    element.setModel(textEditor)
+    element = atom.views.getView(textEditor)
+    element.setUpdatedSynchronously(true)
     element.classList.add('vim-mode')
     statusBarManager ?= new StatusBarManager
     globalVimState ?= new GlobalVimState
@@ -30,7 +30,7 @@ getEditorElement = (callback) ->
       atom.keymaps.handleKeyboardEvent(e)
 
     # mock parent element for the text editor
-    document.createElement('html').appendChild(atom.views.getView(textEditor))
+    document.createElement("html").appendChild(element)
 
     callback(element)
 
@@ -58,7 +58,7 @@ keydown = (key, {element, ctrl, shift, alt, meta, raw}={}) ->
   key = "U+#{key.charCodeAt(0).toString(16)}" unless key is 'escape' or raw?
   element ||= document.activeElement
   eventArgs = [
-    true, # bubbles
+    false, # bubbles
     true, # cancelable
     null, # view
     key,  # key


### PR DESCRIPTION
This will probably fail on Travis, as the new version hasn't been released yet. However, specs pass locally :white_check_mark: and the package seems to work just fine.

The changes in this PR are quite straightforward, but I think it's fine if we :ship: this as soon as the new editor version lands. Also, we should probably bump the engine version in `package.json`.

/cc: @maxbrunsfeld for :eyes: 