### PR TITLE
Implement sentence motions.

### DIFF
--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -96,7 +96,9 @@
   'e': 'vim-mode:move-to-end-of-word'
   'E': 'vim-mode:move-to-end-of-whole-word'
   'b': 'vim-mode:move-to-previous-word'
-  'B': 'vim-mode:move-to-previous-whole-word'
+  'B': 'vim-mode:move-to-previous-whole-word',
+  ')': 'vim-mode:move-to-next-sentence',
+  '(': 'vim-mode:move-to-previous-sentence',
   '}': 'vim-mode:move-to-next-paragraph'
   '{': 'vim-mode:move-to-previous-paragraph'
   '0': 'vim-mode:move-to-beginning-of-line'

--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -296,7 +296,7 @@ class MoveToNextSentence extends Motion
       eof = cursor.editor.getBuffer().getEndPosition()
       scanRange = [start, eof]
 
-      cursor.editor.scanInBufferRange /([\.!?] )|^[A-Za-z0-9]/, scanRange, ({matchText, range, stop}) ->
+      cursor.editor.scanInBufferRange /(^$)|(([\.!?] )|^[A-Za-z0-9])/, scanRange, ({matchText, range, stop}) ->
         adjustment = new Point(0, 0)
         if matchText.match /[\.!?]/
           adjustment = new Point(0, 2)
@@ -311,7 +311,7 @@ class MoveToPreviousSentence extends Motion
       bof = cursor.editor.getBuffer().getFirstPosition()
       scanRange = [bof, end]
 
-      cursor.editor.backwardsScanInBufferRange /([\.!?] )|^[A-Za-z0-9]/, scanRange, ({matchText, range, stop}) ->
+      cursor.editor.backwardsScanInBufferRange /(^$)|(([\.!?] )|^[A-Za-z0-9])/, scanRange, ({matchText, range, stop}) ->
         adjustment = new Point(0, 0)
         if matchText.match /[\.!?]/
           adjustment = new Point(0, 2)

--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -289,6 +289,36 @@ class MoveToEndOfWord extends Motion
 class MoveToEndOfWholeWord extends MoveToEndOfWord
   wordRegex: WholeWordRegex
 
+class MoveToNextSentence extends Motion
+  moveCursor: (cursor, count=1) ->
+    _.times count, ->
+      start = cursor.getBufferPosition().translate new Point(0, 1)
+      eof = cursor.editor.getBuffer().getEndPosition()
+      scanRange = [start, eof]
+
+      cursor.editor.scanInBufferRange /([\.!?] )|^[A-Za-z0-9]/, scanRange, ({matchText, range, stop}) ->
+        adjustment = new Point(0, 0)
+        if matchText.match /[\.!?]/
+          adjustment = new Point(0, 2)
+
+        cursor.setBufferPosition range.start.translate(adjustment)
+        stop()
+
+class MoveToPreviousSentence extends Motion
+  moveCursor: (cursor, count=1) ->
+    _.times count, ->
+      end = cursor.getBufferPosition().translate new Point(0, -1)
+      bof = cursor.editor.getBuffer().getFirstPosition()
+      scanRange = [bof, end]
+
+      cursor.editor.backwardsScanInBufferRange /([\.!?] )|^[A-Za-z0-9]/, scanRange, ({matchText, range, stop}) ->
+        adjustment = new Point(0, 0)
+        if matchText.match /[\.!?]/
+          adjustment = new Point(0, 2)
+
+        cursor.setBufferPosition range.start.translate(adjustment)
+        stop()
+
 class MoveToNextParagraph extends Motion
   moveCursor: (cursor, count=1) ->
     _.times count, ->
@@ -473,7 +503,7 @@ class ScrollFullDownKeepCursor extends ScrollKeepingCursor
 module.exports = {
   Motion, MotionWithInput, CurrentSelection, MoveLeft, MoveRight, MoveUp, MoveDown,
   MoveToPreviousWord, MoveToPreviousWholeWord, MoveToNextWord, MoveToNextWholeWord,
-  MoveToEndOfWord, MoveToNextParagraph, MoveToPreviousParagraph, MoveToAbsoluteLine, MoveToRelativeLine, MoveToBeginningOfLine,
+  MoveToEndOfWord, MoveToNextSentence, MoveToPreviousSentence, MoveToNextParagraph, MoveToPreviousParagraph, MoveToAbsoluteLine, MoveToRelativeLine, MoveToBeginningOfLine,
   MoveToFirstCharacterOfLineUp, MoveToFirstCharacterOfLineDown,
   MoveToFirstCharacterOfLine, MoveToFirstCharacterOfLineAndDown, MoveToLastCharacterOfLine,
   MoveToLastNonblankCharacterOfLineAndDown, MoveToStartOfFile,

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -117,6 +117,8 @@ class VimState
       'move-to-previous-word': => new Motions.MoveToPreviousWord(@editor, this)
       'move-to-previous-whole-word': => new Motions.MoveToPreviousWholeWord(@editor, this)
       'move-to-next-paragraph': => new Motions.MoveToNextParagraph(@editor, this)
+      'move-to-next-sentence': => new Motions.MoveToNextSentence(@editor, this)
+      'move-to-previous-sentence': => new Motions.MoveToPreviousSentence(@editor, this)
       'move-to-previous-paragraph': => new Motions.MoveToPreviousParagraph(@editor, this)
       'move-to-first-character-of-line': => new Motions.MoveToFirstCharacterOfLine(@editor, this)
       'move-to-first-character-of-line-and-down': => new Motions.MoveToFirstCharacterOfLineAndDown(@editor, this)

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -318,7 +318,7 @@ describe "Motions", ->
 
   describe "the ) keybinding", ->
     beforeEach ->
-      editor.setText "This is a sentence. This is a second sentence.\nThis is a third sentence"
+      editor.setText "This is a sentence. This is a second sentence.\nThis is a third sentence.\n\nThis sentence is past the paragraph boundary."
       editor.setCursorBufferPosition [0, 0]
 
     describe "as a motion", ->
@@ -328,6 +328,9 @@ describe "Motions", ->
 
         keydown ')'
         expect(editor.getCursorBufferPosition()).toEqual [1, 0]
+
+        keydown ')'
+        expect(editor.getCursorBufferPosition()).toEqual [2, 0]
 
     describe "as a selection", ->
       beforeEach ->
@@ -339,16 +342,20 @@ describe "Motions", ->
 
   describe "the ( keybinding", ->
     beforeEach ->
-      editor.setText "This is a sentence. This is a second sentence.\nThis is a third sentence"
-      editor.setCursorBufferPosition [1, 0]
+      editor.setText "This first sentence is in its own paragraph.\n\nThis is a sentence. This is a second sentence.\nThis is a third sentence"
+      editor.setCursorBufferPosition [3, 0]
 
     describe "as a motion", ->
       it "moves the cursor to the beginning of the previous sentence", ->
         keydown '('
-        expect(editor.getCursorBufferPosition()).toEqual [0, 20]
+        expect(editor.getCursorBufferPosition()).toEqual [2, 20]
 
         keydown '('
-        expect(editor.getCursorBufferPosition()).toEqual [0, 0]
+        expect(editor.getCursorBufferPosition()).toEqual [2, 0]
+
+        keydown '('
+        expect(editor.getCursorBufferPosition()).toEqual [1, 0]
+
 
     describe "as a selection", ->
       beforeEach ->

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -316,6 +316,48 @@ describe "Motions", ->
         it "selects to the end of the current word", ->
           expect(vimState.getRegister('"').text).toBe 'ab  cde1+-'
 
+  describe "the ) keybinding", ->
+    beforeEach ->
+      editor.setText "This is a sentence. This is a second sentence.\nThis is a third sentence"
+      editor.setCursorBufferPosition [0, 0]
+
+    describe "as a motion", ->
+      it "moves the cursor to the beginning of the next sentence", ->
+        keydown ')'
+        expect(editor.getCursorBufferPosition()).toEqual [0, 20]
+
+        keydown ')'
+        expect(editor.getCursorBufferPosition()).toEqual [1, 0]
+
+    describe "as a selection", ->
+      beforeEach ->
+        keydown('y')
+        keydown(')')
+
+      it 'selects to the start of the next sentence', ->
+        expect(vimState.getRegister('"').text).toBe "This is a sentence. "
+
+  describe "the ( keybinding", ->
+    beforeEach ->
+      editor.setText "This is a sentence. This is a second sentence.\nThis is a third sentence"
+      editor.setCursorBufferPosition [1, 0]
+
+    describe "as a motion", ->
+      it "moves the cursor to the beginning of the previous sentence", ->
+        keydown '('
+        expect(editor.getCursorBufferPosition()).toEqual [0, 20]
+
+        keydown '('
+        expect(editor.getCursorBufferPosition()).toEqual [0, 0]
+
+    describe "as a selection", ->
+      beforeEach ->
+        keydown('y')
+        keydown('(')
+
+      it 'selects to the end of the previous sentence', ->
+        expect(vimState.getRegister('"').text).toBe "This is a second sentence.\n"
+
   describe "the } keybinding", ->
     beforeEach ->
       editor.setText("abcde\n\nfghij\nhijk\n  xyz  \n\nzip\n\n  \nthe end")


### PR DESCRIPTION
This PR implements the traditional `)` and `(` keybindings originally found in vim. I would greatly appreciate any comments and feedback on how I made it work with regex, as I'm certain there may be a slightly slicker way to pull it off (though I've tried to do similar to how other motions are implemented).