### PR TITLE
Fix c/d/y iw/aw commands when run from the first character of a word to not include delimeters

### DIFF
--- a/lib/text-objects.coffee
+++ b/lib/text-objects.coffee
@@ -14,6 +14,8 @@ class TextObject
 class SelectInsideWord extends TextObject
   select: ->
     for selection in @editor.getSelections()
+      if selection.isEmpty()
+        selection.selectRight()
       selection.expandOverWord()
     [true]
 
@@ -144,6 +146,8 @@ class SelectInsideBrackets extends TextObject
 class SelectAWord extends TextObject
   select: ->
     for selection in @editor.getSelections()
+      if selection.isEmpty()
+        selection.selectRight()
       selection.expandOverWord()
       loop
         endPoint = selection.getBufferRange().end

--- a/spec/text-objects-spec.coffee
+++ b/spec/text-objects-spec.coffee
@@ -31,7 +31,7 @@ describe "TextObjects", ->
 
   describe "the 'iw' text object", ->
     beforeEach ->
-      editor.setText("12345 abcde ABCDE")
+      editor.setText("12345 abcde (ABCDE)")
       editor.setCursorScreenPosition([0, 9])
 
     it "applies operators inside the current word in operator-pending mode", ->
@@ -39,7 +39,7 @@ describe "TextObjects", ->
       keydown('i')
       keydown('w')
 
-      expect(editor.getText()).toBe "12345  ABCDE"
+      expect(editor.getText()).toBe "12345  (ABCDE)"
       expect(editor.getCursorScreenPosition()).toEqual [0, 6]
       expect(vimState.getRegister('"').text).toBe "abcde"
       expect(editorElement.classList.contains('operator-pending-mode')).toBe(false)
@@ -60,7 +60,7 @@ describe "TextObjects", ->
       keydown('i')
       keydown('w')
 
-      expect(editor.getSelectedScreenRange()).toEqual [[0, 9], [0, 17]]
+      expect(editor.getSelectedScreenRange()).toEqual [[0, 9], [0, 18]]
 
     it "works with multiple cursors", ->
       editor.addCursorAtBufferPosition([0, 1])
@@ -71,6 +71,15 @@ describe "TextObjects", ->
         [[0, 6], [0, 11]]
         [[0, 0], [0, 5]]
       ]
+
+    it "doesn't expand to include delimeters", ->
+      editor.setCursorScreenPosition([0, 13])
+      keydown('d')
+      keydown('i')
+      keydown('w')
+
+      expect(editor.getText()).toBe "12345 abcde ()"
+
 
   describe "the 'iW' text object", ->
     beforeEach ->


### PR DESCRIPTION
This fixes the current behavior where `ciw` and related commands cut off delimeters before words when on the first letter.  IE for "/foo/bar/whatever"  would become "/foo/whatever" if you navigated to the 'b' and ran `diw`

As far as I can tell this behavior is caused because `selection.expandOverWord` expands to 2 words when the selection is empty and the cursor is "between" 2 words.  Even though vim-mode uses block cursor, atom considers your cursor to be between the "/" word and the "bar" word.  

I've resolved this by explicitly selecting forward if the selection is empty and then expanding to word.  


This closes #868