### PR TITLE
Fix a scroll when contents are wrapped

### DIFF
--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -471,14 +471,20 @@ class ScrollKeepingCursor extends Motion
 
   execute: (count) ->
     # TODO: remove this conditional once after Atom v1.1.0 is released.
-    if @editor.setFirstVisibleScreenRow?
-      newTopRow = @getNewFirstVisibleScreenRow(count)
-      super(count)
-      @editor.setFirstVisibleScreenRow(newTopRow)
-    else
-      scrollTop = @getNewScrollTop(count)
-      super(count)
-      @editorElement.setScrollTop(scrollTop)
+    # TODO: Atom v1.1.0 was released.
+    # But setFirstVisibleScreenRow() use getLineCount() not
+    # getScreenLineCount(). Once after it use getScreenLineCount(),
+    # [1. by setFirstVisibleScreenRow] can be changed to [2. by scrollTop]
+
+    ## 1. by setFirstVisibleScreenRow
+    # newTopRow = @getNewFirstVisibleScreenRow(count)
+    # super(count)
+    # @editor.setFirstVisibleScreenRow(newTopRow)
+
+    ## 2. by scrollTop
+    scrollTop = @getNewScrollTop(count)
+    super(count)
+    @editorElement.setScrollTop(scrollTop)
 
   moveCursor: (cursor) ->
     cursor.setScreenPosition(Point(@cursorRow, 0), autoscroll: false)

--- a/lib/scroll.coffee
+++ b/lib/scroll.coffee
@@ -12,8 +12,10 @@ class Scroll
 class ScrollDown extends Scroll
   execute: (count=1) ->
     oldFirstRow = @editor.getFirstVisibleScreenRow()
-    @editor.setFirstVisibleScreenRow(oldFirstRow + count)
-    newFirstRow = @editor.getFirstVisibleScreenRow()
+    newFirstRow = oldFirstRow + count
+    oldScrollTop = @editorElement.getScrollTop()
+    newScrollTop = oldScrollTop + @editor.getLineHeightInPixels()*count
+    @editorElement.setScrollTop( newScrollTop )
 
     for cursor in @editor.getCursors()
       position = cursor.getScreenPosition()
@@ -28,10 +30,11 @@ class ScrollDown extends Scroll
 
 class ScrollUp extends Scroll
   execute: (count=1) ->
-    oldFirstRow = @editor.getFirstVisibleScreenRow()
-    oldLastRow = @editor.getLastVisibleScreenRow()
-    @editor.setFirstVisibleScreenRow(oldFirstRow - count)
-    newLastRow = @editor.getLastVisibleScreenRow()
+    oldLastRow = @editorElement.getLastVisibleScreenRow()
+    newLastRow = oldLastRow - count
+    oldScrollTop = @editorElement.getScrollTop()
+    newScrollTop = oldScrollTop - @editor.getLineHeightInPixels()*count
+    @editorElement.setScrollTop( newScrollTop )
 
     for cursor in @editor.getCursors()
       position = cursor.getScreenPosition()


### PR DESCRIPTION
In the document that has many wrapped contents, scroll handling commands (ctrl-d, ctrl-f and ctrl-e) can NOT move screen to end of document.

This PR refers to #968.
To explain the problem more details, I uploaded a video file.
[video reproduce the problem](https://youtu.be/cu8EDDZt_aU)

I hope it is helpful to check and review my PR.
Thank you.