### PR TITLE
:bug: Fix repeat-insertion bug referenced in #1006

### DIFF
--- a/lib/operators/input.coffee
+++ b/lib/operators/input.coffee
@@ -13,8 +13,10 @@ class Insert extends Operator
   isComplete: -> @standalone or super
 
   confirmChanges: (changes) ->
-    bundler = new TransactionBundler(changes, @editor)
-    @typedText = bundler.buildInsertText()
+    if changes.length > 0
+      @typedText = changes[0].newText
+    else
+      @typedText = ""
 
   execute: ->
     if @typingCompleted
@@ -134,33 +136,6 @@ class Change extends Insert
       @typingCompleted = true
     else
       @vimState.activateNormalMode()
-
-# Takes a transaction and turns it into a string of what was typed.
-# This class is an implementation detail of Insert
-class TransactionBundler
-  constructor: (@changes, @editor) ->
-    @start = null
-    @end = null
-
-  buildInsertText: ->
-    @addChange(change) for change in @changes
-    if @start?
-      @editor.getTextInBufferRange [@start, @end]
-    else
-      ""
-
-  addChange: (change) ->
-    return unless change.newExtent?
-    if @start?
-      if @start.isGreaterThanOrEqual(change.start)
-        @start = change.start
-    else
-      @start = change.start
-    if @end?
-      if @end.isLessThanOrEqual(change.start.translate(change.newExtent))
-        @end = change.start.translate(change.newExtent)
-    else
-      @end = change.start.translate(change.newExtent)
 
 
 module.exports = {

--- a/lib/operators/input.coffee
+++ b/lib/operators/input.coffee
@@ -150,55 +150,17 @@ class TransactionBundler
       ""
 
   addChange: (change) ->
-    return unless change.newRange?
-    if @isRemovingFromPrevious(change)
-      @subtractRange change.oldRange
-    if @isAddingWithinPrevious(change)
-      @addRange change.newRange
-
-  isAddingWithinPrevious: (change) ->
-    return false unless @isAdding(change)
-
-    return true if @start is null
-
-    @start.isLessThanOrEqual(change.newRange.start) and
-      @end.isGreaterThanOrEqual(change.newRange.start)
-
-  isRemovingFromPrevious: (change) ->
-    return false unless @isRemoving(change) and @start?
-
-    @start.isLessThanOrEqual(change.oldRange.start) and
-      @end.isGreaterThanOrEqual(change.oldRange.end)
-
-  isAdding: (change) ->
-    change.newText.length > 0
-
-  isRemoving: (change) ->
-    change.oldText.length > 0
-
-  addRange: (range) ->
-    if @start is null
-      {@start, @end} = range
-      return
-
-    rows = range.end.row - range.start.row
-
-    if (range.start.row is @end.row)
-      cols = range.end.column - range.start.column
+    return unless change.newExtent?
+    if @start?
+      if @start.isGreaterThanOrEqual(change.start)
+        @start = change.start
     else
-      cols = 0
-
-    @end = @end.translate [rows, cols]
-
-  subtractRange: (range) ->
-    rows = range.end.row - range.start.row
-
-    if (range.end.row is @end.row)
-      cols = range.end.column - range.start.column
+      @start = change.start
+    if @end?
+      if @end.isLessThanOrEqual(change.start.translate(change.newExtent))
+        @end = change.start.translate(change.newExtent)
     else
-      cols = 0
-
-    @end = @end.translate [-rows, -cols]
+      @end = change.start.translate(change.newExtent)
 
 
 module.exports = {

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -453,7 +453,7 @@ class VimState
     @editorElement.component.setInputEnabled(false)
     @editorElement.classList.remove('replace-mode')
     @editor.groupChangesSinceCheckpoint(@insertionCheckpoint)
-    changes = getChangesSinceCheckpoint(@editor.buffer, @insertionCheckpoint)
+    changes = @editor.buffer.getChangesSinceCheckpoint(@insertionCheckpoint)
     item = @inputOperator(@history[0])
     @insertionCheckpoint = null
     if item?
@@ -670,13 +670,3 @@ class VimState
       cursor.goalColumn = goalColumn
 
     @editor.mergeCursors()
-
-# This uses private APIs and may break if TextBuffer is refactored.
-# Package authors - copy and paste this code at your own risk.
-getChangesSinceCheckpoint = (buffer, checkpoint) ->
-  {history} = buffer
-
-  if (index = history.getCheckpointIndex(checkpoint))?
-    history.undoStack.slice(index)
-  else
-    []


### PR DESCRIPTION
Hi all,

I took a shot at fixing the repeat-insertions-after-change bug referenced in #1006 and #1010. As @t9md pointed out, there is an issue with `item.confirmChanges(changes)` function of the `Insert` class. That function constructs an instance of `TransactionBundler` which relies on `change.newRange` and some other properties which don't exist. As a result, `bundler.buildInsertText()` always returns `""`, which is why the dot-command after `cwText` repeats the deletion, but not the insertion.

This fix makes use of the `getChangesSinceCheckpoint` function, implemented in atom/text-buffer@9f9025fd7dbac7b1bf2ebc58bf1176df9d9f251c. That function replaces the function of the same name implemented in `lib/vim-state.coffee`, which uses private API's. It essentially supplies equivalent information in a different format. The `TransactionBundler` class is changed accordingly.

The dot-command now behaves as expected on conventional patterns like `iText`, `cwText`, `c2wText`, `ccText`, etc.

There is some funky behavior when moving the cursor outside of the edited region while in insert-mode and continuing to type (not when fixing something that was just typed). However, I don't think this is a result of this fix, but rather a consequence of the way `TransactionBundler` bundles the inserted text by calling `@editor.getTextInBufferRange`. Similar behavior occurs using the release version of the vim-mode package on the 1.6.2 Atom release, when the dot-command was still working. To illustrate, take

`One two three.`

In command-mode, move the cursor to the beginning of `two`. Type `cwHello` which replaces `two` by `Hello`. Without leaving insert-mode, move the cursor to the beginning of the line and type `world.<space><escape>`. I see

`world. One Hello three.`

Now move the cursor to the beginning of the word `three` and hit `.`. I see in

Atom 1.7.3 + this fix:
`world. One Hello world. One Hello.`
All of `world. One Hello` is taken to be the typed text, and hence re-inserted after hitting `.`. Everything between insertions is grouped together and taken to be typed text, even if it was there before.

Atom 1.6.2 + vim-mode 0.65.0
`world. One Hello d. One H.`
This time `d. One H` is taken to be the typed text and reinserted after hitting `.`.

(Neo)vim
`world. One Hello world. three.`
In vim, it seems like `cw` is forgotten about once the cursor leaves the original region. `.` simply repeats the last insert (`world.<space>`) and does not delete `three`.

Since this kind of pattern isn't really the intended use of the `cw`, it's hard to say what the behavior should be, but the difference to vim is worth noting.

Feedback is greatly appreciated.




