### PR TITLE
Add config to override the default register used

### DIFF
--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -10,6 +10,10 @@ settings =
     wrapLeftRightMotion:
       type: 'boolean'
       default: false
+    overrideDefaultRegister:
+      type: 'string',
+      default: '',
+      description: 'Enter the key of the register (other than "), to override the default register used'
     useClipboardAsDefaultRegister:
       type: 'boolean'
       default: true
@@ -23,6 +27,8 @@ Object.keys(settings.config).forEach (k) ->
     atom.config.get('vim-mode.'+k)
 
 settings.defaultRegister = ->
-  if settings.useClipboardAsDefaultRegister() then '*' else '"'
+  defaultRegister = if settings.overrideDefaultRegister() then settings.overrideDefaultRegister() else '""
+  '
+  if settings.useClipboardAsDefaultRegister() then '*' else defaultRegister
 
 module.exports = settings


### PR DESCRIPTION
This has frustrated me for a while: At many keyboards the mapping to access the `"` key is quite cumbersome, in that it is not necessarily caught by the Atom event system (I discovered this by playing around with the Keybinding resolver). This makes it near impossible to access the default register as it is in the current implementation. This is especially true on many international keyboards (me myself having a Norwegian keyboard layout).

Also, I feel it is handy to be able to map the default register to a different key, so I created this PR. It adds a config field that is read from when populating the `settings` module, and defaults to the `"` register, so it is all backwards compatible.