### PR TITLE
Make paragraph forward match Vim's behavior re: whitespace.

### DIFF
--- a/lib/motions/general-motions.coffee
+++ b/lib/motions/general-motions.coffee
@@ -322,7 +322,16 @@ class MoveToPreviousSentence extends Motion
 class MoveToNextParagraph extends Motion
   moveCursor: (cursor, count=1) ->
     _.times count, ->
-      cursor.moveToBeginningOfNextParagraph()
+      start = cursor.getBufferPosition()
+      eof = cursor.editor.getEofBufferPosition()
+      scanRange = [start, eof]
+      position = start
+
+      cursor.editor.scanInBufferRange /[^\n]\n(?=\n)|[^\r\n]\r\n(?=\r\n)/, scanRange, ({range, stop}) ->
+        position = range.end
+        stop() if position.isGreaterThan(start)
+      position = eof if position.isEqual(start)
+      cursor.setBufferPosition(position)
 
 class MoveToPreviousParagraph extends Motion
   moveCursor: (cursor, count=1) ->

--- a/spec/motions-spec.coffee
+++ b/spec/motions-spec.coffee
@@ -366,7 +366,7 @@ describe "Motions", ->
 
   describe "the } keybinding", ->
     beforeEach ->
-      editor.setText("abcde\n\nfghij\nhijk\n  xyz  \n\nzip\n\n  \nthe end")
+      editor.setText("abcde\n\n\nfghij\nhijk\n  xyz  \n\nzip\n\n  \n  \n\n \nthe end")
       editor.setCursorScreenPosition([0, 0])
 
     describe "as a motion", ->
@@ -375,13 +375,16 @@ describe "Motions", ->
         expect(editor.getCursorScreenPosition()).toEqual [1, 0]
 
         keydown('}')
-        expect(editor.getCursorScreenPosition()).toEqual [5, 0]
+        expect(editor.getCursorScreenPosition()).toEqual [6, 0]
 
         keydown('}')
-        expect(editor.getCursorScreenPosition()).toEqual [7, 0]
+        expect(editor.getCursorScreenPosition()).toEqual [8, 0]
 
         keydown('}')
-        expect(editor.getCursorScreenPosition()).toEqual [9, 6]
+        expect(editor.getCursorScreenPosition()).toEqual [11, 0]
+
+        keydown('}')
+        expect(editor.getCursorScreenPosition()).toEqual [13, 6]
 
     describe "as a selection", ->
       beforeEach ->


### PR DESCRIPTION
:bug: Consecutive empty lines should not be treated as different paragraphs and
whitespace only lines are not paragraph boundaries.

http://vimdoc.sourceforge.net/htmldoc/motion.html#paragraph

I went in to fix the failing test on forward paragraph behavior and noticed that vim-mode also didn't match Vim for whitespace only line behavior. If this PR makes sense I can also take a look at backwards paragraph motion.