### PR TITLE
Add deprecation notice to package description

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vim-mode",
   "main": "./lib/vim-mode",
   "version": "0.65.1",
-  "description": "Add vim modal control",
+  "description": "Deprecated - please install vim-mode-plus instead",
   "license": "MIT",
   "private": true,
   "repository": "https://github.com/atom/vim-mode",


### PR DESCRIPTION
This builds on #1070 and changes the package description to make it clear that vim-mode-plus should be installed instead.  After this is merged a new patch should be released.

We should also consider moving this repository to the atom-archive organization.

/cc @maxbrunsfeld @t9md